### PR TITLE
Updates to README and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "riot-wrappers"
 version = "0.7.22"
-authors = ["Christian M. Amsüss <ca@etonomy.org>"]
+authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 
 description = "Rust API wrappers for the RIOT operating system"
 documentation = "https://rustdoc.etonomy.org/riot_wrappers/"
-repository = "https://gitlab.com/etonomy/riot-wrappers"
-readme = "README.md"
+repository = "https://github.com/RIOT-OS/rust-riot-wrappers"
 keywords = ["riot", "riot-os", "iot", "bindings", "embedded-hal-impl"]
 categories = ["api-bindings", "no-std"]
 # This is chosen to ease code migration between this and other implementations

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ The [crate documentation](https://rustdoc.etonomy.org/riot_wrappers/) outlines w
 modules are available, and which other crates' traits they implement.
 
 For a newcomer's starting point, see [RIOT's documentation on using it with Rust].
-For code examples of many of the wrapped APIs, see the
-[examples](https://gitlab.com/etonomy/riot-examples/).
+For basic code examples see [RIOT's examples](https://github.com/RIOT-OS/RIOT/tree/master/examples)
+(those with "rust" in their name), and the
+[additional examples](https://gitlab.com/etonomy/riot-examples/)
+which showcase more of the wrapped APIs.
 
 [RIOT's documentation on using it with Rust]: https://doc.riot-os.org/using-rust.html
 
@@ -39,7 +41,7 @@ part of RIOT's example directory.
 Supported RIOT & Rust versions
 ------------------------------
 
-Currently, RIOT this crate targets the latest development version of RIOT.
+Currently, this crate targets the latest development version of RIOT.
 Support for the latest release is maintained on a best-effort basis.
 
 For most parts of this library, this crate requires a nightly version of Rust;
@@ -78,11 +80,9 @@ and profit from better integration.
 Code conventions
 ----------------
 
-In older pieces of code (until [1344] has been solved), static inline RIOT functions
+In older pieces of code (predating the use of C2Rust), static inline RIOT functions
 or expanded macros are used. To keep track of them, comments in the shape of
 ``EXPANDED ${FILE}:${LINE}`` are set (referring to line numbers in RIOT commit 6b96f69b).
-
-[1344]: https://github.com/rust-lang/rust-bindgen/issues/1344
 
 As these are being replaced by using C2Rust idioms, conflicts between C2Rust's
 and bindgen's versions of structs arise instead, typically around pointers. When these

--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ Apache 2.0 license, as is commonplace in the embedded Rust ecosystem.
 Note that it crate depends on `riot-sys`, which is licensed under RIOT's LGPL
 2.1 to reflect that it uses code transpiled from RIOT.
 
-The crate is maintained by Christian M. Amsüss <ca@etonomy.org> as part of the etonomy
-project, see <https://etonomy.org/>.
+The crate is maintained by Christian Amsüss <chrysn@fsfe.org> as part of the etonomy
+project, see <https://etonomy.org/>, and the RIOT team.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,13 @@
+//! Safe and idiomatic Rust wrappers for [RIOT-OS]
+//!
+//! See [RIOT's documentation on using Rust] for a general introduction to Rust on RIOT, [this
+//! crate's README file] on general concepts (such as the interaction between modules here, RIOT
+//! modules and features), and the individual modules' documentation entries for details.
+//!
+//! [RIOT-OS]: https://www.riot-os.org/
+//! [RIOT's documentation on using Rust]: https://doc.riot-os.org/using-rust.html
+//! [this crate's README file]: https://github.com/RIOT-OS/rust-riot-wrappers
+
 #![no_std]
 // for eh_personality; only needed on native
 #![cfg_attr(


### PR DESCRIPTION
* It's now maintained inside RIOT
* Some crate docs were added (enough to get the pointers to more docs)
* Minor corrections