### PR TITLE
Adjust to Gcoap handler taking a coap_request_ctx_t rather than a void*

### DIFF
--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use riot_sys::libc::c_void;
-use riot_sys::{coap_optpos_t, coap_pkt_t, gcoap_listener_t, coap_request_ctx_t};
+use riot_sys::{coap_optpos_t, coap_pkt_t, gcoap_listener_t};
 
 #[cfg(marker_gcoap_resource_t)]
 use riot_sys::gcoap_resource_t;
@@ -13,6 +13,11 @@ use riot_sys::coap_resource_t;
 #[cfg(not(marker_gcoap_resource_t))]
 #[allow(non_camel_case_types)]
 type gcoap_resource_t = coap_resource_t;
+
+#[cfg(marker_coap_request_ctx_t)]
+type HandlerArg4 = riot_sys::coap_request_ctx_t;
+#[cfg(not(marker_coap_request_ctx_t))]
+type HandlerArg4 = c_void;
 
 /// Give the caller a way of registering Gcoap handlers into the global Gcoap registry inside a
 /// callback. When the callback terminates, the registered handlers are deregistered again,
@@ -146,9 +151,15 @@ where
         pkt: *mut coap_pkt_t,
         buf: *mut u8,
         len: u32,
-        context: *mut coap_request_ctx_t,
+        context: *mut HandlerArg4,
     ) -> i32 {
+        #[cfg(marker_coap_request_ctx_t)]
+        /* The remaining information in the request_ctx is inaccessible through the CoAP handler
+         * API as it is now */
         let h = riot_sys::coap_request_ctx_get_context(context) as *mut H;
+        #[cfg(not(marker_coap_request_ctx_t))]
+        let h = context as *mut H;
+
         let h = &mut *h;
         let mut pb = PacketBuffer {
             pkt,

--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -3,7 +3,7 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use riot_sys::libc::c_void;
-use riot_sys::{coap_optpos_t, coap_pkt_t, gcoap_listener_t};
+use riot_sys::{coap_optpos_t, coap_pkt_t, gcoap_listener_t, coap_request_ctx_t};
 
 #[cfg(marker_gcoap_resource_t)]
 use riot_sys::gcoap_resource_t;
@@ -146,9 +146,9 @@ where
         pkt: *mut coap_pkt_t,
         buf: *mut u8,
         len: u32,
-        context: *mut c_void,
+        context: *mut coap_request_ctx_t,
     ) -> i32 {
-        let h = context as *mut H;
+        let h = riot_sys::coap_request_ctx_get_context(context) as *mut H;
         let h = &mut *h;
         let mut pb = PacketBuffer {
             pkt,


### PR DESCRIPTION
Building on https://github.com/RIOT-OS/rust-riot-sys/pull/5, this add support for the RIOT API change of https://github.com/RIOT-OS/RIOT/pull/17957 in a way that is transparent to coap-handler users. (The extra information now accessible is lost to Rust users, but any change there would likely be an API change on the coap-handler/coap-message side, exposing the new features, or a new API that gives lower-level control of request handling).

### Testing

* Green CI
* https://github.com/RIOT-OS/RIOT/pull/17957 switches over to using this and *also* gets a green CI