### PR TITLE
Remove obsolete code after marker freezes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 nb = "0.1.1"
-riot-sys = "0.7.3"
+riot-sys = "0.7.8"
 num-traits = { version = "0.2", default-features = false }
 mutex-trait = "0.2"
 

--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -5,14 +5,7 @@ use core::mem::MaybeUninit;
 use riot_sys::libc::c_void;
 use riot_sys::{coap_optpos_t, coap_pkt_t, gcoap_listener_t};
 
-#[cfg(marker_gcoap_resource_t)]
-use riot_sys::gcoap_resource_t;
-// Before <https://github.com/RIOT-OS/RIOT/pull/17544>, gcoap just used nanocoap's coap_resource_t.
-#[cfg(not(marker_gcoap_resource_t))]
 use riot_sys::coap_resource_t;
-#[cfg(not(marker_gcoap_resource_t))]
-#[allow(non_camel_case_types)]
-type gcoap_resource_t = coap_resource_t;
 
 #[cfg(marker_coap_request_ctx_t)]
 type HandlerArg4 = riot_sys::coap_request_ctx_t;
@@ -80,7 +73,7 @@ pub trait ListenerProvider {
     unsafe fn get_listener<'a>(&'a mut self) -> &'a mut gcoap_listener_t;
 }
 
-/// A combination of the gcoap_resource_t and gcoap_listener_t structs with only a single resource
+/// A combination of the coap_resource_t and gcoap_listener_t structs with only a single resource
 /// (Compared to many resources, this allows easier creation in Rust at the expense of larger
 /// memory consumption and slower lookups in Gcoap).
 ///
@@ -88,7 +81,7 @@ pub trait ListenerProvider {
 /// x.`[`register`](RegistrationScope::register)`(l) })`.
 pub struct SingleHandlerListener<'a, H> {
     _phantom: PhantomData<&'a H>,
-    resource: gcoap_resource_t,
+    resource: coap_resource_t,
     listener: gcoap_listener_t,
 }
 
@@ -102,7 +95,7 @@ where
 
         SingleHandlerListener {
             _phantom: PhantomData,
-            resource: gcoap_resource_t {
+            resource: coap_resource_t {
                 path: path.as_ptr(),
                 handler: Some(Self::call_handler),
                 methods: methods,

--- a/src/saul.rs
+++ b/src/saul.rs
@@ -565,7 +565,6 @@ impl Unit {
             riot_sys::UNIT_V => Some(Unit::V),
             riot_sys::UNIT_W => Some(Unit::W),
             riot_sys::UNIT_GS => Some(Unit::Gs),
-            #[cfg(marker_phydat_unit_t)]
             riot_sys::UNIT_T => Some(Unit::T),
             riot_sys::UNIT_DBM => Some(Unit::Dbm),
             riot_sys::UNIT_COULOMB => Some(Unit::Coulomb),
@@ -606,10 +605,7 @@ impl Unit {
             Some(Unit::V) => riot_sys::UNIT_V,
             Some(Unit::W) => riot_sys::UNIT_W,
             Some(Unit::Gs) => riot_sys::UNIT_GS,
-            #[cfg(marker_phydat_unit_t)]
             Some(Unit::T) => riot_sys::UNIT_T,
-            #[cfg(not(marker_phydat_unit_t))]
-            Some(Unit::T) => riot_sys::UNIT_UNDEF,
             Some(Unit::Dbm) => riot_sys::UNIT_DBM,
             Some(Unit::Coulomb) => riot_sys::UNIT_COULOMB,
             Some(Unit::F) => riot_sys::UNIT_F,

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -197,7 +197,6 @@ pub struct MountIter {
 }
 
 impl MountIter {
-    #[cfg(marker_vfs_iterate_mount_dirs)]
     pub fn next(&mut self) -> Option<Mount<'_>> {
         // unsafe: Our dir is always either zeroed or managed by mount_dirs
         if unsafe { riot_sys::vfs_iterate_mount_dirs(self.dir.as_mut_ptr()) } {
@@ -211,11 +210,6 @@ impl MountIter {
             self.dir = MaybeUninit::zeroed();
             None
         }
-    }
-
-    #[cfg(not(marker_vfs_iterate_mount_dirs))]
-    pub fn next(&mut self) -> Option<Mount<'_>> {
-        None
     }
 
     fn is_zeroed(&self) -> bool {

--- a/src/ztimer/periodic.rs
+++ b/src/ztimer/periodic.rs
@@ -4,12 +4,6 @@ use core::marker::PhantomPinned;
 use core::mem::MaybeUninit;
 use core::pin::Pin;
 
-#[cfg(not(marker_ztimer_periodic_callback_t))]
-type PeriodicReturnType = riot_sys::libc::c_int;
-#[cfg(marker_ztimer_periodic_callback_t)]
-type PeriodicReturnType =
-    <riot_sys::ztimer_periodic_callback_t as crate::helpers::ReturnTypeExtractor>::ReturnType;
-
 /// Return value of a periodic callback
 #[derive(Copy, Clone, Debug)]
 pub enum Behavior {
@@ -110,7 +104,7 @@ impl<H: Handler, const HZ: u32> Timer<H, HZ> {
         }
     }
 
-    extern "C" fn callback(arg: *mut riot_sys::libc::c_void) -> PeriodicReturnType {
+    extern "C" fn callback(arg: *mut riot_sys::libc::c_void) -> bool {
         let handler = unsafe { &mut *(arg as *mut H) };
         handler.trigger().into()
     }


### PR DESCRIPTION
<del>Do not merge yet: This will need to bump the riot-sys depenedency to the one where the markers are actually frozen (0.7.8), but that's not out yet.</del>

This removes some obsolete ifdefs required only for RIOT versions earlier than the currently stable one, and that was there to accommodate API breaking PRs that were eventually not accepted.