### PR TITLE
saul: Tolerate switched callback pointer type

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,12 +4,26 @@
 /// <https://github.com/rust-lang/rust/issues/43301#issuecomment-912390203> -- also useful to
 /// extract return types of functions that (in what is compatible behavior in C) change their
 /// return types.
+///
+/// With the introduction of ArgXType, it's actually not a ReturnType but AnyFunctionInvolvedType
+/// extractor any more...
 pub trait ReturnTypeExtractor {
     type ReturnType;
+    type Arg1Type;
+    type Arg2Type;
 }
 impl<T> ReturnTypeExtractor for fn() -> T {
     type ReturnType = T;
+    type Arg1Type = ();
+    type Arg2Type = ();
 }
 impl<T, I1> ReturnTypeExtractor for Option<unsafe extern "C" fn(I1) -> T> {
     type ReturnType = T;
+    type Arg1Type = I1;
+    type Arg2Type = ();
+}
+impl<T, I1, I2> ReturnTypeExtractor for Option<unsafe extern "C" fn(I1, I2) -> T> {
+    type ReturnType = T;
+    type Arg1Type = I1;
+    type Arg2Type = I2;
 }

--- a/src/saul.rs
+++ b/src/saul.rs
@@ -71,7 +71,10 @@ pub trait Drivable: Sized + Sync {
         }
     }
 
-    unsafe extern "C" fn write_raw(dev: *const libc::c_void, data: *mut raw::phydat_t) -> i32 {
+    unsafe extern "C" fn write_raw(
+        dev: *const libc::c_void,
+        data: registration::WritePhydatPointer,
+    ) -> i32 {
         let device = &*(dev as *const Self);
         let data = *data;
         // PHYDAT_DIM: See write documentation

--- a/src/saul/registration.rs
+++ b/src/saul/registration.rs
@@ -79,6 +79,20 @@ where
     _phantom: core::marker::PhantomData<(DEV, DRIV)>,
 }
 
+/// This flipped from *mut phydat_t to *const in https://github.com/RIOT-OS/RIOT/pull/18043
+pub(crate) type WritePhydatPointer =
+    <riot_sys::saul_write_t as crate::helpers::ReturnTypeExtractor>::Arg2Type;
+
+// While the old supported RIOT version has a `saul_notsup` and the new has
+// `saul_{read,write}_notsup`, it's easier to just implement our own. After the 2022.07 release
+// they can go away again, and users go with riot_sys::saul_[...]_notsup
+extern "C" fn saul_read_notsup(_dev: *const libc::c_void, _dat: *mut riot_sys::phydat_t) -> i32 {
+    -(riot_sys::ENOTSUP as i32)
+}
+extern "C" fn saul_write_notsup(_dev: *const libc::c_void, _dat: WritePhydatPointer) -> i32 {
+    -(riot_sys::ENOTSUP as i32)
+}
+
 impl<DEV, DRIV> Driver<DEV, DRIV>
 where
     DEV: Sized + Sync + 'static,
@@ -91,12 +105,12 @@ where
                 read: if DRIV::HAS_READ {
                     Some(Self::read_raw)
                 } else {
-                    Some(riot_sys::saul_notsup)
+                    Some(saul_read_notsup)
                 },
                 write: if DRIV::HAS_WRITE {
                     Some(Self::write_raw)
                 } else {
-                    Some(riot_sys::saul_notsup)
+                    Some(saul_write_notsup)
                 },
                 type_: DRIV::CLASS.to_c(),
             },
@@ -117,7 +131,7 @@ where
         }
     }
 
-    unsafe extern "C" fn write_raw(dev: *const libc::c_void, data: *mut riot_sys::phydat_t) -> i32 {
+    unsafe extern "C" fn write_raw(dev: *const libc::c_void, data: WritePhydatPointer) -> i32 {
         let device = &*(dev as *const DEV);
         let device = device.into();
         let data = *data;


### PR DESCRIPTION
This was not spotted in [18043] that caused the API break, because none
of the CI built examples have SAUL enabled.

[18043]: https://github.com/RIOT-OS/RIOT/pull/18043