### PR TITLE
Re-export riot-sys, use it in static_command!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,15 @@
 // Primarily for documentation, see feature docs
 #![cfg_attr(feature = "actual_never_type", feature(never_type))]
 
+/// riot-sys is re-exported here as it is necessary in some places when using it to get values (eg.
+/// in [error::NumericError::from_constant]). It is also used in macros such as [static_command!].
+///
+/// ### Stability
+///
+/// By directly mapping RIOT APIs, this is more volatile than the rest of riot-wrappers. Use this
+/// only where necessary to utilize riot-wrappers APIs.
+pub use riot_sys;
+
 pub use cstr_core as cstr;
 
 pub mod error;

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -441,13 +441,13 @@ macro_rules! static_command {
             // The transparent allows the &StaticCommand to have the right properties to be storable in a
             // static, and still be the same pointer.
             #[repr(transparent)]
-            pub struct StaticCommand(riot_sys::shell_command_t);
+            pub struct StaticCommand($crate::riot_sys::shell_command_t);
 
             // unsafe: OK due to the only construction way (the CStr is created from a literal and
             // thus static, and the_function is static by construction as well)
             unsafe impl Sync for StaticCommand {}
 
-            static THE_STRUCT: StaticCommand = StaticCommand(riot_sys::shell_command_t {
+            static THE_STRUCT: StaticCommand = StaticCommand($crate::riot_sys::shell_command_t {
                 name: $crate::cstr::cstr!($name).as_ptr(),
                 desc: $crate::cstr::cstr!($descr).as_ptr(),
                 handler: Some(the_function),
@@ -458,7 +458,7 @@ macro_rules! static_command {
 
             unsafe extern "C" fn the_function(
                 argc: i32,
-                argv: *mut *mut riot_sys::libc::c_char,
+                argv: *mut *mut $crate::riot_sys::libc::c_char,
             ) -> i32 {
                 let marker = ();
                 let args = unsafe { $crate::shell::Args::new(argc, argv as _, &marker) };


### PR DESCRIPTION
The static_command! macro previously required the using crate to also
use riot-sys. As the need to pick a suitable riot-sys has been annoying
in different places, this adds a public re-export of riot-sys, which can
then be used by macros and users.