### PR TITLE
Release 0.7.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.7.22"
+version = "0.7.23"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 


### PR DESCRIPTION
Changes:

* Adjust to RIOT API changes after 2022.04 in SAUL and Gcoap
* Publicly export the used version of riot-sys
* Remove ifdefs for API variations before 2022.04
* Documentation fixes
* Migrate into the RIOT project, to
  https://github.com/RIOT-OS/rust-riot-wrappers
* Adjust CI to RIOT's hoster