### PR TITLE
CI: Make buildtest more verbose

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -48,7 +48,7 @@ jobs:
           echo "::group::Building ${D}"
           cargo update -p riot-sys -p riot-wrappers
           cargo tree
-          make buildtest
+          make buildtest BUILDTEST_MAKE_REDIRECT=''
           cd ../..
           echo "::endgroup::"
         done


### PR DESCRIPTION
Currently, failures just look like this:

```
Building for native ... success.
Building for sltb001a ... failed!
Building for samr21-xpro ... failed!
```

This enables debug output, as it already was back on GitLab.