### PR TITLE
dependencies: Use released cstr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ mutex-trait = "0.2"
 
 bare-metal = "1"
 
-# https://github.com/upsuper/cstr/pull/14 is expected to be merged and released soon
-cstr = { git = "https://github.com/chrysn-pull-requests/cstr", branch = "no-std-3" }
+cstr = "^0.2.11"
 
 heapless = "^0.7"
 


### PR DESCRIPTION
This was temporarily switched to a pre-release version in https://github.com/RIOT-OS/rust-riot-wrappers/pull/10 but now is generally available.