### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.7.23"
+version = "0.8.0"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 


### PR DESCRIPTION
Changes:

* All deprecated modules and features removed.

  Noteworthy are the ones that did not perviously raise deprecation warnings automatically:

  * Features that were previously default are now not default any more. A crate that is a main application should now use the `set_panic_handler` feature.

  * rnrc::Pktsnip does not implement From<*mut gnrc_pktsnip_t> any more
  * i2c::Error and thread::StackStats are now non_exhaustive

* Several error types changed from Option<T> or Result<T, ()> to meaningful ZST errors. These are located in the thread, GNRC and gcoap modules, and are best found by the compiler.

* stdio::read_raw now returns the raw error code error::NumericError.

* The crate's CStr switched from the cstr_core crate to the recently stabilized core::CStr. There is still a crate publically re-exported as the cstr module (now the cstr crate); that should not be used, but is necessary for macros.

* saul::RegistryEntry::all() now has a named return type

* CoAP crate dependencies were updated to versions that are buildable on beta

* A note on versioning was added to the README

---

Procedurally, I plan to wait for this to run through, some riot-rs to be published (even if just as a placeholder), to `cargo publish`, and then merge this fast-forwardly.