### PR TITLE
mutex: Panic when called from interrupt context

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -42,6 +42,12 @@ impl<T> Mutex<T> {
     /// Get an accessor to the mutex when the mutex is available
     #[doc(alias = "mutex_lock")]
     pub fn lock(&self) -> MutexGuard<T> {
+        assert!(
+            crate::interrupt::irq_is_in() == false,
+            "Mutex::lock may only be called outside of interrupt contexts.",
+        );
+        // unsafe: All preconditions of the C function are met (not-NULL through taking a &self,
+        // being initialized through RAII guarantees, thread context was checked before).
         unsafe { riot_sys::mutex_lock(crate::inline_cast_mut(self.mutex.get())) };
         MutexGuard { mutex: &self }
     }


### PR DESCRIPTION
This is a precondition of the C code, and might be UB otherwise.

---

Explicitly checking might bring a performance impact, and removes us from being a zero-cost abstraction, but safety is a preeminent requirement for Rust wrappers.