### PR TITLE
Add tokens for being in a thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,9 @@ with_msg_v2 = []
 # This is primarily for documentation building; enabling it may also help users
 # of nightly when they see a mess of types.
 actual_never_type = []
+
+# Enable documentation enhancements that depend on nightly
+#
+# This has some effects of its own (making ValueInThread fundamental), and also
+# enables actual_never_type.
+nightly_docs = [ "actual_never_type" ]

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -27,6 +27,7 @@
 /// [`irq_is_in`](https://doc.riot-os.org/group__core__irq.html#ga83decbeef665d955290f730125ef0e3f)
 ///
 /// Returns true when called from an interrupt service routine
+#[deprecated(note = "Use crate::thread::InThread::new() instead")]
 pub fn irq_is_in() -> bool {
     unsafe { riot_sys::irq_is_in() }
 }
@@ -37,8 +38,22 @@ pub fn irq_is_in() -> bool {
 /// Returns true if interrupts are currently enabled
 ///
 /// Note that this only returns reliable values when called from a thread context.
+#[deprecated(note = "use crate::thread::InThread::irq_is_enabled() instead")]
 pub fn irq_is_enabled() -> bool {
     unsafe { riot_sys::irq_is_enabled() }
+}
+
+impl crate::thread::InThread {
+    /// Trivial safe wrapper for
+    /// [`irq_is_enabled`](https://doc.riot-os.org/group__core__irq.html#ga7fa965063ff2f4f4cea34f1c2a8fac25)
+    ///
+    /// Returns true if interrupts are currently enabled
+    ///
+    /// Using this on an `InThread` token is preferred over the global function, as the function
+    /// only returns reliable values when called from a thread context.
+    pub fn irq_is_enabled(self) -> bool {
+        unsafe { riot_sys::irq_is_enabled() }
+    }
 }
 
 /// Proof of running inside a critical section. Reexported from the [bare_metal] crate.

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -71,7 +71,7 @@ pub fn free<R, F: FnOnce(&CriticalSection) -> R>(f: F) -> R {
 ///
 /// This is Cortex-M specific.
 #[deprecated(
-    note = "See module documentation: This needs to be done manually per platform; it is incomplete as riot-wrappers provides no method of enabling platform specific interrupts, and provides no other access to configure the peripheral through registers. If it is re-introduced, it will likely carry an `InIrq` token into the function."
+    note = "See module documentation: This needs to be done manually per platform; it is incomplete as riot-wrappers provides no method of enabling platform specific interrupts, and provides no other access to configure the peripheral through registers. If it is re-introduced, it will likely carry an `InIsr` token into the function."
 )]
 #[macro_export]
 macro_rules! interrupt {

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -18,7 +18,10 @@
 //!
 //! Rust code intended for use within interrupts does not generally need special precautions -- but
 //! several functions (generally, anything that blocks) are discouraged (as they may fail or stall
-//! the system) outside of a thread context.
+//! the system) outside of a thread context, or even "forbidden" (because they reliably lock up the
+//! system, such as [crate::mutex::Mutex::lock()]). These functions often have preferred
+//! alternatives that can be statically known to be executed in a thread context by keeping a copy
+//! of [`crate::thread::InThread`].
 
 /// Trivial safe wrapper for
 /// [`irq_is_in`](https://doc.riot-os.org/group__core__irq.html#ga83decbeef665d955290f730125ef0e3f)

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -28,9 +28,7 @@
 ///
 /// Returns true when called from an interrupt service routine
 pub fn irq_is_in() -> bool {
-    // "as u32" cast: Necessary for versions before https://github.com/RIOT-OS/RIOT/pull/17359
-    // (2022.01)
-    (unsafe { riot_sys::irq_is_in() }) as u32 != 0
+    unsafe { riot_sys::irq_is_in() }
 }
 
 /// Trivial safe wrapper for
@@ -40,9 +38,7 @@ pub fn irq_is_in() -> bool {
 ///
 /// Note that this only returns reliable values when called from a thread context.
 pub fn irq_is_enabled() -> bool {
-    // "as u32" cast: Necessary for versions before https://github.com/RIOT-OS/RIOT/pull/17359
-    // (2022.01)
-    (unsafe { riot_sys::irq_is_enabled() }) as u32 != 0
+    unsafe { riot_sys::irq_is_enabled() }
 }
 
 /// Proof of running inside a critical section. Reexported from the [bare_metal] crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 )]
 // Primarily for documentation, see feature docs
 #![cfg_attr(feature = "actual_never_type", feature(never_type))]
+#![cfg_attr(feature = "nightly_docs", feature(fundamental))]
 
 /// riot-sys is re-exported here as it is necessary in some places when using it to get values (eg.
 /// in [error::NumericError::from_constant]). It is also used in macros such as [static_command!].

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -40,6 +40,14 @@ impl<T> Mutex<T> {
     }
 
     /// Get an accessor to the mutex when the mutex is available
+    ///
+    /// ## Panics
+    ///
+    /// This function checks at runtime whether it is called in a thread context, and panics
+    /// otherwise. Consider promoting a reference with an [`InThread`](crate::thread::InThread)
+    /// token's [`.promote(&my_mutex)`](crate::thread::InThread::promote) to gain access to a
+    /// better [`.lock()`](crate::thread::ValueInThread<&Mutex<T>>::lock) method, which suffers
+    /// neither the panic condition nor the runtime overhead.
     #[doc(alias = "mutex_lock")]
     pub fn lock(&self) -> MutexGuard<T> {
         crate::thread::InThread::new()
@@ -80,7 +88,7 @@ impl<T> Mutex<T> {
     /// be dropped (or even leaked-and-pushed-off-the-stack) even in a locked state. (A possibility
     /// that is fine -- we sure don't want to limit mutex usage to require a Pin reference.)
     ///
-    /// The function could be generalized to some generic lifetime, but there doesn't seem to b a
+    /// The function could be generalized to some generic lifetime, but there doesn't seem to be a
     /// point to it.
     pub fn try_leak(&'static self) -> Option<&'static mut T> {
         let guard = self.try_lock()?;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -23,7 +23,7 @@ pub use riot_c::*;
 mod tokenparts;
 #[cfg(doc)]
 pub use tokenparts::TokenParts;
-pub use tokenparts::{StartToken, TerminationToken};
+pub use tokenparts::{InIrq, InThread, StartToken, TerminationToken};
 
 mod stack_stats;
 pub use stack_stats::{StackStats, StackStatsError};

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -23,7 +23,7 @@ pub use riot_c::*;
 mod tokenparts;
 #[cfg(doc)]
 pub use tokenparts::TokenParts;
-pub use tokenparts::{InIrq, InThread, StartToken, TerminationToken};
+pub use tokenparts::{InIrq, InThread, StartToken, TerminationToken, ValueInThread};
 
 mod stack_stats;
 pub use stack_stats::{StackStats, StackStatsError};

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -23,7 +23,7 @@ pub use riot_c::*;
 mod tokenparts;
 #[cfg(doc)]
 pub use tokenparts::TokenParts;
-pub use tokenparts::{InIrq, InThread, StartToken, TerminationToken, ValueInThread};
+pub use tokenparts::{InIsr, InThread, StartToken, TerminationToken, ValueInThread};
 
 mod stack_stats;
 pub use stack_stats::{StackStats, StackStatsError};

--- a/src/thread/tokenparts.rs
+++ b/src/thread/tokenparts.rs
@@ -208,6 +208,7 @@ impl InThread {
     /// Note that this is actually running code; to avoid that, call [`TokenParts::in_thread()`],
     /// which is a purely type-level procedure.
     pub fn new() -> Result<Self, InIsr> {
+        #[allow(deprecated)] // It's deprecatedly pub
         match crate::interrupt::irq_is_in() {
             true => Err(unsafe { InIsr::new_unchecked() }),
             false => Ok(unsafe { InThread::new_unchecked() }),

--- a/src/thread/tokenparts.rs
+++ b/src/thread/tokenparts.rs
@@ -192,7 +192,7 @@ pub struct InThread {
 
 /// Zero-size statement that the current code is running in an interrupt
 #[derive(Copy, Clone, Debug)]
-pub struct InIrq {
+pub struct InIsr {
     _not_send: PhantomData<*const ()>,
 }
 
@@ -207,9 +207,9 @@ impl InThread {
     ///
     /// Note that this is actually running code; to avoid that, call [`TokenParts::in_thread()`],
     /// which is a purely type-level procedure.
-    pub fn new() -> Result<Self, InIrq> {
+    pub fn new() -> Result<Self, InIsr> {
         match crate::interrupt::irq_is_in() {
-            true => Err(unsafe { InIrq::new_unchecked() }),
+            true => Err(unsafe { InIsr::new_unchecked() }),
             false => Ok(unsafe { InThread::new_unchecked() }),
         }
     }
@@ -224,9 +224,9 @@ impl InThread {
     }
 }
 
-impl InIrq {
+impl InIsr {
     unsafe fn new_unchecked() -> Self {
-        InIrq {
+        InIsr {
             _not_send: PhantomData,
         }
     }

--- a/src/thread/tokenparts.rs
+++ b/src/thread/tokenparts.rs
@@ -244,6 +244,8 @@ impl InIrq {
 ///
 /// This does barely implement anything on its own, but the module implementing `T` might provide
 /// extra methods.
+// Making the type fundamental results in ValueInThread<&Mutex<T>> being shown at Mutex's page.
+#[cfg_attr(feature = "nightly_docs", fundamental)]
 pub struct ValueInThread<T> {
     value: T,
     in_thread: InThread,


### PR DESCRIPTION
Tokens for being-in-a-thread have only been a comment previously, and came to prominence through https://github.com/RIOT-OS/rust-riot-wrappers/issues/18 and [a reddit thread](https://www.reddit.com/r/linux/comments/xt9uq2/comment/iqqa0pv/).

As a first demo, the tokens can be used with a Mutex when locking. This does not close #18, as the mutex function stays as it is -- but it might be deprecated, or (compatibly ... how?) changed to return a Result that the user would then need to unwrap (but does that make it better? Might it just be deprecated?).

As they work just the same, it also adds tokens for "being in an interrupt context", although there's probably not much that can be done with them (because interrupts could still be nested).

### Advanced usage

More APIs should probably switch from being implemented on an X to being implemented on ValueInThread<X>. I2C transfers come to mind.

APIs that explicitly send data between threads might want to offer ways to also transport ValueInThread. I'm not sure yet whether that's more easily achieved by allowing either trait requirement (is that possible even?), or whether they'd just transport `.into_inner()` and then use the recipient's knowledge of being in a thread to reconstitute the wrapper.

### Alternatives

Rather than having a single wrapper for any T that is not sent to interrupt contexts, it would be possible to have a Mutex type with generic variants (eg. const IS_IN_THREAD: bool).

The largest upside of that alternative is documentation visibility: [ValueInThread](https://rustdoc.etonomy.org/riot_wrappers/thread/struct.ValueInThread.html)<&[Mutex](https://rustdoc.etonomy.org/riot_wrappers/mutex/struct.Mutex.html)<T>> is documented with ValueInThread, not with Mutex.