### PR TITLE
LEDs: Add switch-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
+switch-hal = "0.4.0"
 nb = "0.1.1"
 riot-sys = "0.7.8"
 num-traits = { version = "0.2", default-features = false }


### PR DESCRIPTION
Closes: https://gitlab.com/etonomy/riot-wrappers/-/issues/5

The GPIO implementation is left in place, both for compatibility and for convenience.