### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 rust-version = "1.65"


### PR DESCRIPTION
Changes:

* TokenParts: Add InThread and InIsr, deprecating `irq_is_in` & co.
* Add ValueInThread based on InThread, allowing safer use of a Mutex
* Shell: Provide more practical `run_providing_buf` method, deprecating the methods that take a buffer.
* Unify `riot_main` and `riot_main_with_tokens`, deprecating the latter.
* LEDs: Implement switch-hal
* Rename `TerminationToken` to `EndToken` (and `.termination()` to `.can_end()`)
* Mutex: Panic instead of trying to lock in an ISR
* Add tests

---

Except for this change that changes the version number, this is exactly what RIOT uses since https://github.com/RIOT-OS/RIOT/pull/19193.