### PR TITLE
Fix and tests mutex wrapper

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -54,7 +54,7 @@ jobs:
         done
         cd ..
         echo "::echo ::off"
-    - name: Build tests
+    - name: Build and run tests
       run: |
         export BOARDS='native sltb001a samr21-xpro'
         DIRS=$(echo tests/*/)
@@ -66,7 +66,12 @@ jobs:
           cd ${D}
           echo "::group::Building ${D}"
           make buildtest BUILDTEST_MAKE_REDIRECT=''
-          cd ../..
           echo "::endgroup::"
+          if make test/available BOARD=native; then
+            echo "::group::Testing ${D}"
+            make all test BOARD=native
+            echo "::endgroup::"
+          fi
+          cd ../..
         done
         echo "::echo ::off"

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -52,7 +52,7 @@ impl<T> Mutex<T> {
     pub fn lock(&self) -> MutexGuard<T> {
         crate::thread::InThread::new()
             .expect("Mutex::lock may only be called outside of interrupt contexts")
-            .promote(&self)
+            .promote(self)
             .lock()
     }
 
@@ -97,13 +97,13 @@ impl<T> Mutex<T> {
     }
 }
 
-impl<T> crate::thread::ValueInThread<&Mutex<T>> {
+impl<'a, T> crate::thread::ValueInThread<&'a Mutex<T>> {
     /// Get an accessor to the mutex when the mutex is available
     ///
     /// Through the [crate::thread::ValueInThread], this is already guaranteed to run in a thread
     /// context, so no additional check is performed.
     #[doc(alias = "mutex_lock")]
-    pub fn lock(&self) -> MutexGuard<T> {
+    pub fn lock(self) -> MutexGuard<'a, T> {
         // unsafe: All preconditions of the C function are met (not-NULL through taking a &self,
         // being initialized through RAII guarantees, thread context is in the InThread).
         unsafe { riot_sys::mutex_lock(crate::inline_cast_mut(self.mutex.get())) };

--- a/src/thread/tokenparts.rs
+++ b/src/thread/tokenparts.rs
@@ -254,6 +254,7 @@ impl InIsr {
 /// This does barely implement anything on its own, but the module implementing `T` might provide
 /// extra methods.
 // Making the type fundamental results in ValueInThread<&Mutex<T>> being shown at Mutex's page.
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "nightly_docs", fundamental)]
 pub struct ValueInThread<T> {
     value: T,

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,5 +3,8 @@ Tests for riot-wrappers
 
 Running these tests requires setting the RIOTBASE environment variable to a checkout of RIOT.
 
-The tests are mainly intended as build tests;
-they can be run safely though, provided the board files are correct.
+All tests work as build tests.
+
+The tests can all safely be run (`make flash term`) on any board (provided the board files are correct),
+and some have test runners (`make test`) that work for some or all boards.
+These are run in CI for native.

--- a/tests/led/tests/01-run.py
+++ b/tests/led/tests/01-run.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from testrunner import run
+
+def test(child):
+    # Both LEDs light up at some point
+    child.expect("LED_RED_TOGGLE")
+    child.expect("LED_GREEN_TOGGLE")
+
+if __name__ == "__main__":
+    if os.environ['BOARD'] != 'native':
+        print("Automated test only works on native (other boards don't report hteir LED activity)", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(run(test))

--- a/tests/mutex/Cargo.toml
+++ b/tests/mutex/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "riot-wrappers-test-mutex"
+version = "0.1.0"
+authors = ["Christian Amsüss <chrysn@fsfe.org>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+[profile.release]
+panic = "abort"
+
+[dependencies]
+riot-wrappers = { version = "*", features = [ "set_panic_handler" ] }

--- a/tests/mutex/Makefile
+++ b/tests/mutex/Makefile
@@ -1,0 +1,7 @@
+APPLICATION = riot-wrappers-test-mutex
+BOARD ?= native
+APPLICATION_RUST_MODULE = riot_wrappers_test_mutex
+BASELIBS += $(APPLICATION_RUST_MODULE).module
+FEATURES_REQUIRED += rust_target
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/mutex/src/lib.rs
+++ b/tests/mutex/src/lib.rs
@@ -1,0 +1,28 @@
+#![no_std]
+
+use riot_wrappers::mutex::Mutex;
+use riot_wrappers::println;
+use riot_wrappers::riot_main;
+use riot_wrappers::thread::{InThread, ValueInThread};
+
+riot_main!(main);
+
+static M1: Mutex<()> = Mutex::new(());
+
+fn main() {
+    let l1 = M1.lock();
+    drop(l1);
+    let m1 = InThread::new().unwrap().promote(&M1);
+    let l2 = m1.lock();
+    assert!(m1.try_lock().is_none());
+    drop(l2);
+    let l3 = m1.try_lock();
+    assert!(l3.is_some());
+    drop(l3);
+
+    let m2 = Mutex::new(0u8);
+    *m2.lock() = 4;
+    assert!(*m2.lock() == 4);
+
+    println!("SUCCESS");
+}

--- a/tests/mutex/tests/01-run.py
+++ b/tests/mutex/tests/01-run.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+def test(child):
+    child.expect("SUCCESS")
+
+if __name__ == "__main__":
+    sys.exit(run(test))


### PR DESCRIPTION
This primarily fixes #41, and adds infrastructure to also run (not only build) tests, as well as a test that'd have caught this.