### PR TITLE
tests: Add test for auto-init when auto-init debug is active

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -41,7 +41,11 @@ fn main() {
         let bindgen_output = std::fs::read_to_string(bindgen_output_file)
             .expect("Failed to read BINDGEN_OUTPUT_FILE");
 
-        if bindgen_output.contains("pub const CONFIG_AUTO_INIT_ENABLE_DEBUG: u32 = 1;") {
+        // Whether or not the extra space is there depends on whether or not rustfmt is installed.
+        // FIXME: Find a better way to extract that information
+        if bindgen_output.contains("pub const CONFIG_AUTO_INIT_ENABLE_DEBUG: u32 = 1;")
+            || bindgen_output.contains("pub const CONFIG_AUTO_INIT_ENABLE_DEBUG : u32 = 1 ;")
+        {
             println!("cargo:rustc-cfg=marker_config_auto_init_enable_debug");
         }
     } else {

--- a/src/auto_init.rs
+++ b/src/auto_init.rs
@@ -25,7 +25,7 @@ impl AutoInitModule {
             result = Self(riot_sys::auto_init_module_t {
                 init: Some(init_function),
                 prio: priority,
-                name: name.as_ptr(),
+                name: name.as_ptr() as _,
             });
         }
         #[cfg(not(marker_config_auto_init_enable_debug))]

--- a/tests/auto-init-debug/Cargo.toml
+++ b/tests/auto-init-debug/Cargo.toml
@@ -1,0 +1,1 @@
+../auto-init/Cargo.toml

--- a/tests/auto-init-debug/Makefile
+++ b/tests/auto-init-debug/Makefile
@@ -1,0 +1,3 @@
+CFLAGS += -DCONFIG_AUTO_INIT_ENABLE_DEBUG=1
+
+include ../auto-init/Makefile

--- a/tests/auto-init-debug/src
+++ b/tests/auto-init-debug/src
@@ -1,0 +1,1 @@
+../auto-init/src

--- a/tests/auto-init-debug/tests/01-run.py
+++ b/tests/auto-init-debug/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from testrunner import run
+
+def test(child):
+    # avoiding parentheses in the numbers -- these are regexps!
+    child.expect("auto_init: auto_early .1.")
+    child.expect("Early auto initialization")
+    child.expect("auto_init: auto_late .65535.")
+    child.expect("Late auto initialization")
+    child.expect("Main running")
+
+if __name__ == "__main__":
+    if os.environ['BOARD'] != 'native':
+        print("Automated test only works on native (other boards' early output is lost)", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(run(test))


### PR DESCRIPTION
A signed-vs-unsigned char bug hid in code that's dead without debug that only manifests on ARM.