### PR TITLE
build: Use `syn` to pick out constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ pin-utils = "0.1"
 
 [build-dependencies]
 shlex = "0.1.1"
+syn = { version = "1.0.107", features = [ "parsing" ] }
 
 [features]
 default = []


### PR DESCRIPTION
As #48 has shown, picking flags out of the bindgen output is relatively brittle. It worked well for as long as we were only checking for some string's presence, but for CONFIG_ things we need a bit more.

This just uses the `syn` parser to parse the source code; that's a well established tool that's also used in proc macros.

Leaving this as a draft for a while to gather input and think more about it, but so far I like it.