### PR TITLE
saul: Make Unit non_exhaustive

### DIFF
--- a/src/saul.rs
+++ b/src/saul.rs
@@ -359,6 +359,7 @@ pub enum SensorClass {
 #[derive(Copy, Clone, Debug)]
 /// Unit of measurement required to interpret numeric values in a [Phydat] exchanged with a SAUL
 /// device
+#[non_exhaustive]
 pub enum Unit {
     /// Note that this means "data has no physical unit", and is distinct from "No unit given",
     /// which is `Option::<Unit>::None` as opposed to `Some(Unit::None)`.


### PR DESCRIPTION
This is a breaking change, and should be held until short before the next "major" version change.

It will allow adding new variants, and should have been done from the start.