### PR TITLE
gnrc: Fix address conversion build failure

### DIFF
--- a/src/gnrc/ipv6.rs
+++ b/src/gnrc/ipv6.rs
@@ -180,7 +180,7 @@ impl From<embedded_nal::Ipv6Addr> for Address {
 #[cfg(feature = "with_embedded_nal")]
 impl From<Address> for embedded_nal::Ipv6Addr {
     fn from(addr: Address) -> Self {
-        Self::from(self.raw())
+        Self::from(*addr.raw())
     }
 }
 


### PR DESCRIPTION
When building with_embedded_nal, a build regression was introduced in 0ecf87e765f7264e79226540b694eb50993c7882 through careless refactoring. This restores buildability.

There is currently no test that'd have triggered this; adding tests is somewhere on the agenda, but fixing it is more urgent.