### PR TITLE
random/tests: Small improvements

### DIFF
--- a/tests/random/Cargo.toml
+++ b/tests/random/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler" ] }
+riot-wrappers = { version = "*", features = [ "set_panic_handler", "panic_handler_format" ] }
 rand_core = "0.6"
 rngcheck = "0.1.1"

--- a/tests/random/src/lib.rs
+++ b/tests/random/src/lib.rs
@@ -9,6 +9,7 @@ riot_main!(main);
 fn check_csrng(mut rng: impl rand_core::CryptoRng + rand_core::RngCore) {
     use rngcheck::{helpers::*, nist::*};
 
+    // This is also in https://github.com/ryankurte/rngcheck/pull/3
     struct BitIter<'a, R: rand_core::RngCore> {
         rng: &'a mut R,
         remaining: usize,
@@ -62,8 +63,8 @@ fn check_csrng(mut rng: impl rand_core::CryptoRng + rand_core::RngCore) {
         nist_freq_block(BitIter::new(&mut rng, count), 16).unwrap()
     );
 
-    println!("Generating 10 more random numbers");
-    for _ in 0..10 {
+    println!("Generating 3 more random numbers");
+    for _ in 0..3 {
         println!("{}", rng.next_u32());
     }
 


### PR DESCRIPTION
* If any of the tests fail, panic_format ensures the output can be understood easily.
* Some code was sent upstream to [1], a note ensures the local code can be removed when ready.
* Reducing the count of printed numbers to ensure that the default USB output buffer displays all relevant information and not just literally random stuff.

[1]: https://github.com/ryankurte/rngcheck/pull/3