### PR TITLE
CI: Run own tests instead of RIOT tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  quick-examples:
+  examples-and-tests:
     runs-on: ubuntu-latest
     container: riot/riotbuild
     # Best would be "continue until there are errors from different examples *and* different boards"
     continue-on-error: true
     strategy:
       matrix:
+        # This is the subset of `make -f makefiles/app_dirs.inc.mk
+        # info-applications` that is probably relevant; more is covered when
+        # riot-wrappers are updated in RIOT.
         example: [examples/rust-hello-world, examples/rust-gcoap, tests/rust_minimal]
         board: [native, sltb001a, samr21-xpro, stk3700]
     steps:
@@ -56,12 +59,31 @@ jobs:
       run: |
         make all BOARD=${{ matrix.board }} -C RIOT/${{ matrix.example }}
 
-  most-tests:
+  enumerate-wrappers-tests:
     runs-on: ubuntu-latest
+    outputs:
+      list:  ${{ steps.enumerate.outputs.tests }}
+    steps:
+    - name: Check out riot-wrappers
+      uses: actions/checkout@v3
+    - name: List tests in riot-wrappers
+      id: enumerate
+      run: |
+        echo "tests=[$(ls -d tests/*/ -1 | sed 's/.*/\"&\"/' | tr '\n' ',' | sed 's/,$//')]" >> "${GITHUB_OUTPUT}"
+        cat "${GITHUB_OUTPUT}"
+    - name: Set job summary
+      run: |
+        # This doubles as a check to see that our JSON is right
+        echo 'Local tests were enumerated to be `${{ toJSON(fromJSON( steps.enumerate.outputs.tests )) }}`' >> $GITHUB_STEP_SUMMARY
+
+  wrappers-tests:
+    runs-on: ubuntu-latest
+    needs: enumerate-wrappers-tests
     container: riot/riotbuild
     strategy:
       matrix:
         board: [native, sltb001a, samr21-xpro, stk3700]
+        testdir: ${{ fromJSON(needs.enumerate-wrappers-tests.outputs.list) }}
     steps:
     # common steps start here
     - name: Check out riot-wrappers
@@ -95,51 +117,25 @@ jobs:
         done
     # common steps end here
 
-    - name: Build and run tests
+    - name: Build and run test
       run: |
         set -x
         export RIOTBASE=$(pwd)/RIOT
-        # Removing tests/pkg/lvgl due to https://github.com/RIOT-OS/RIOT/issues/20110
-        #
-        # Skipping examples because ... not sure, did it that way before
-        # https://github.com/RIOT-OS/rust-riot-wrappers/pull/68, and examples
-        # are built extra
-        #
-        # Skipping peripheral and driver tests because we don't implement those
-        # with wrappers; the valuable ones are those like saul where there are
-        # modules that use Rust.
-        DIRS=$(make --quiet -C ${RIOTBASE} -f makefiles/app_dirs.inc.mk info-applications | grep -v tests/pkg/lvgl |grep -v examples |grep -v periph |grep -v driver)
-        for D in ${DIRS}; do
-          echo "::group::Building ${D}"
-          cd ${D}
-          if BOARDS=${{ matrix.board }} make info-boards-supported | grep -q .
-          then
-            # RIOTNOLINK is a workaround for boards with insufficient memory
-            # showing as supported but still being known not to be buildable.
-            # Other CI works around by having RIOT_CI_BUILD set RIOTNOLINK if
-            # the board is known to not have enough memory from
-            # BOARD_INSUFFICIENT_MEMORY, but that information is not piped out.
-            #
-            # Until a better workaround is found, no boards are linked, and if
-            # a board does exceed its memory due to a Rust change, that will
-            # only be spotted when the Rust crate is updated in RIOT and a full
-            # test with the precise criterion is run.
-            BOARD=${{ matrix.board }} make all RIOTNOLINK=1
+        cd ${{ matrix.testdir }}
+        if BOARDS=${{ matrix.board }} make info-boards-supported | grep -q .
+        then
+          BOARD=${{ matrix.board }} make all
 
-            if [ "native" = "${{ matrix.board }}" ] && make test/available BOARD=native
-            then
-              echo "::group::Testing ${D}"
-              make all test BOARD=native
-              echo "::endgroup::"
-            fi
-            BOARD=${{ matrix.board }} make clean
-          else
-            echo "Board is not supported for this test, skipping."
+          if [ "native" = "${{ matrix.board }}" ] && make test/available BOARD=native
+          then
+            echo
+            echo "Testing ${D}"
+            echo
+            make all test BOARD=native
           fi
-          cd -
-          echo "::endgroup::"
-        done
-        echo "::echo ::off"
+        else
+          echo "Board is not supported for this test, skipping."
+        fi
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,3 +146,11 @@ jobs:
         fetch-depth: 0
     - name: Run cargo-fmt
       run: cargo fmt --check
+
+  all-done:
+    needs: [rustfmt, wrappers-tests, examples-and-tests]
+    # It'd suffice to just do "needs", but GitHub actions insist to have steps
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "All done"
+


### PR DESCRIPTION
The tests are now run using individual steps for the same reasons the examples were switched over.

In [68], the tests were accidentally switched over to running all RIOT instead of all own tests (which may also make sense but is really excessive, and most importantly lost the own tests)

[68]: https://github.com/RIOT-OS/rust-riot-wrappers/pull/68