### PR TITLE
Bump version to 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 rust-version = "1.65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.4", features = ["u
 embedded-hal = "1"
 switch-hal = "0.4.0"
 nb = "0.1.1"
-riot-sys = "0.7.8"
+riot-sys = "0.7.10"
 num-traits = { version = "0.2", default-features = false }
 mutex-trait = "0.2"
 

--- a/tests/.cargo/config.toml
+++ b/tests/.cargo/config.toml
@@ -1,3 +1,0 @@
-[patch.crates-io]
-riot-wrappers = { path = ".." }
-riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }

--- a/tests/adc/Cargo.toml
+++ b/tests/adc/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler" ] }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }
 riot-sys = "*"
 embedded-hal = "0.2.4"

--- a/tests/auto-init/Cargo.toml
+++ b/tests/auto-init/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler" ] }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }

--- a/tests/dac/Cargo.toml
+++ b/tests/dac/Cargo.toml
@@ -12,8 +12,4 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler" ] }
-riot-sys = "*"
-
-[patch.crates-io]
-riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }

--- a/tests/gnrc-pktbuf/Cargo.toml
+++ b/tests/gnrc-pktbuf/Cargo.toml
@@ -12,8 +12,5 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler", "panic_handler_format" ] }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 riot-sys = "*"
-
-[patch.crates-io]
-riot-sys = { git = "https://github.com/RIOT-OS/rust-riot-sys" }

--- a/tests/gpio/Cargo.toml
+++ b/tests/gpio/Cargo.toml
@@ -12,6 +12,5 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler", "panic_handler_format" ] }
-riot-sys = "*"
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 embedded-hal = "1"

--- a/tests/i2c/Cargo.toml
+++ b/tests/i2c/Cargo.toml
@@ -12,6 +12,5 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler", "panic_handler_format" ] }
-riot-sys = "*"
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 embedded-hal = "1"

--- a/tests/led/Cargo.toml
+++ b/tests/led/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler" ] }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }
 switch-hal = "0.4"

--- a/tests/mutex/Cargo.toml
+++ b/tests/mutex/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler" ] }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }

--- a/tests/random/Cargo.toml
+++ b/tests/random/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler", "panic_handler_format" ] }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 rand_core = "0.6"
 rngcheck = "0.1.1"

--- a/tests/ztimer-async/Cargo.toml
+++ b/tests/ztimer-async/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib"]
 panic = "abort"
 
 [dependencies]
-riot-wrappers = { version = "*", features = [ "set_panic_handler", "panic_handler_format", "embedded-hal-async", "provide_critical_section_1_0" ] }
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format", "embedded-hal-async", "provide_critical_section_1_0" ] }
 embassy-executor-riot = { git = "https://gitlab.com/etonomy/riot-module-examples" }
 embassy-executor = "0.5.0" # Not enabling any of its executors: there's the -riot for that
 static_cell = "2"


### PR DESCRIPTION
Marking the version currently being pulled into RIOT in https://github.com/RIOT-OS/RIOT/pull/20303

* Add autoinit module.
* Drop SUIT support. The module was in such disrepair in the previous that it was apparently not used.
* SAUL: Compatibly follow renaming of G* units done in C
* Add constants for common error values.
* Add initializers based on peripheral numbers.
* Add BOARD const.
* gcoap:
  * Allow registration without scope for 'static listeners
  * Provide link encoder based on coap_handler::wkc
  * Support coap-message 0.3 / coap-handler 0.2
* Support embedded-hal 1.0 on selected modules.
* Add tests for mutex and random.
* Small refactorings.
* Fixes to existing tests.
* riot-sys is pulled to the latest version in this commit because there is no cross-version testing happening.