### PR TITLE
Drop nightly options for rustfmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,11 +139,13 @@ jobs:
 
   rustfmt:
     runs-on: ubuntu-latest
-    container: rustlang/rust:nightly
+    container: docker.io/rust
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Add rustfmt component
+      run: rustup component add rustfmt
     - name: Run cargo-fmt
       run: cargo fmt --check
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-unstable_features = true
-imports_layout = "HorizontalVertical"
-blank_lines_upper_bound = 2

--- a/src/coap_handler/v0_2.rs
+++ b/src/coap_handler/v0_2.rs
@@ -6,10 +6,7 @@ use core::convert::TryInto;
 use coap_handler_0_2::{Attribute, Handler, Record, Reporting};
 
 use coap_message_0_3::{
-    error::RenderableOnMinimal,
-    MinimalWritableMessage,
-    MutableWritableMessage,
-    ReadableMessage,
+    error::RenderableOnMinimal, MinimalWritableMessage, MutableWritableMessage, ReadableMessage,
 };
 
 use crate::coap_message::ResponseMessage;

--- a/src/coap_message/impl_0_2.rs
+++ b/src/coap_message/impl_0_2.rs
@@ -1,8 +1,5 @@
 use coap_message_0_2::{
-    MessageOption,
-    MinimalWritableMessage,
-    MutableWritableMessage,
-    ReadableMessage,
+    MessageOption, MinimalWritableMessage, MutableWritableMessage, ReadableMessage,
     WithSortedOptions,
 };
 

--- a/src/coap_message/impl_0_3.rs
+++ b/src/coap_message/impl_0_3.rs
@@ -1,11 +1,6 @@
 use coap_message_0_3::{
-    error::RenderableOnMinimal,
-    Code,
-    MessageOption,
-    MinimalWritableMessage,
-    MutableWritableMessage,
-    ReadableMessage,
-    WithSortedOptions,
+    error::RenderableOnMinimal, Code, MessageOption, MinimalWritableMessage,
+    MutableWritableMessage, ReadableMessage, WithSortedOptions,
 };
 
 use crate::error::NumericError;

--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -246,7 +246,6 @@ fn link_encoder_safe<H: WithLinkEncoder>(
     }
 }
 
-
 impl<'a, H> SingleHandlerListener<'a, H>
 where
     H: 'a + Handler + WithLinkEncoder,
@@ -336,10 +335,7 @@ pub trait WithLinkEncoder {
 }
 
 use riot_sys::{
-    coap_opt_add_opaque,
-    coap_opt_add_uint,
-    coap_opt_get_next,
-    gcoap_register_listener,
+    coap_opt_add_opaque, coap_opt_add_uint, coap_opt_get_next, gcoap_register_listener,
     gcoap_resp_init,
 };
 

--- a/src/gnrc_pktbuf.rs
+++ b/src/gnrc_pktbuf.rs
@@ -4,14 +4,8 @@ use core::marker::PhantomData;
 use core::mem::forget;
 
 use riot_sys::{
-    gnrc_netif_hdr_build,
-    gnrc_nettype_t,
-    gnrc_pktbuf_add,
-    gnrc_pktbuf_hold,
-    gnrc_pktbuf_realloc_data,
-    gnrc_pktbuf_release_error,
-    gnrc_pktsnip_t,
-    GNRC_NETERR_SUCCESS,
+    gnrc_netif_hdr_build, gnrc_nettype_t, gnrc_pktbuf_add, gnrc_pktbuf_hold,
+    gnrc_pktbuf_realloc_data, gnrc_pktbuf_release_error, gnrc_pktsnip_t, GNRC_NETERR_SUCCESS,
 };
 
 /// Error type for pktsnip operations that need free buffer space

--- a/src/gnrc_util.rs
+++ b/src/gnrc_util.rs
@@ -12,9 +12,7 @@ use crate::thread::KernelPID;
 #[cfg(riot_module_gnrc_udp)]
 use riot_sys::gnrc_nettype_t_GNRC_NETTYPE_UDP as GNRC_NETTYPE_UDP;
 use riot_sys::{
-    gnrc_netif_hdr_t,
-    gnrc_nettype_t_GNRC_NETTYPE_NETIF as GNRC_NETTYPE_NETIF,
-    udp_hdr_t,
+    gnrc_netif_hdr_t, gnrc_nettype_t_GNRC_NETTYPE_NETIF as GNRC_NETTYPE_NETIF, udp_hdr_t,
 };
 
 /// Trait of data structures that store all the information needed to respond to a Pktsnip in some

--- a/src/microbit.rs
+++ b/src/microbit.rs
@@ -3,11 +3,7 @@
 //! [microbit module]: https://doc.riot-os.org/group__boards__common__microbit.html
 
 use embedded_graphics::{
-    drawable::Pixel,
-    geometry::Point,
-    geometry::Size,
-    pixelcolor::BinaryColor,
-    DrawTarget,
+    drawable::Pixel, geometry::Point, geometry::Size, pixelcolor::BinaryColor, DrawTarget,
 };
 
 use crate::Never;

--- a/src/saul.rs
+++ b/src/saul.rs
@@ -23,7 +23,6 @@ use error::NegativeErrorExt;
 
 pub mod registration;
 
-
 /// A discovered SAUL registry entry
 pub struct RegistryEntry(*mut riot_sys::saul_reg);
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -385,7 +385,6 @@ pub fn new() -> impl CommandList {
     CommandListEnd
 }
 
-
 /// Make a function whose signature is `fn(&mut `[`Stdio`](stdio::Stdio)`, `[`Args`]`<'b>) -> impl `[`Termination`](crate::main::Termination) available through
 /// XFA in any RIOT shell, even when called throuch C. (The function's signature may be more
 /// generic, eg. accepting an `impl `[`Write`](core::fmt::Write) and an `impl `[`IntoIterator`]`<&str>`).

--- a/src/socket_embedded_nal.rs
+++ b/src/socket_embedded_nal.rs
@@ -136,7 +136,6 @@ impl<'a, const UDPCOUNT: usize> StackAccessor<'a, UDPCOUNT> {
         // that the stack is available for 'a and won't move.
         let socket: &'a mut _ = unsafe { &mut *socket };
 
-
         handle.socket = Some(socket);
 
         Ok(())

--- a/src/spi/mod.rs
+++ b/src/spi/mod.rs
@@ -1,13 +1,7 @@
 use crate::Never;
 use embedded_hal_0_2::blocking;
 use riot_sys::{
-    spi_acquire,
-    spi_clk_t,
-    spi_cs_t,
-    spi_mode_t,
-    spi_release,
-    spi_t,
-    spi_transfer_bytes,
+    spi_acquire, spi_clk_t, spi_cs_t, spi_mode_t, spi_release, spi_t, spi_transfer_bytes,
 };
 
 pub struct SPIDevice(#[deprecated(note = "Use constructor instead")] pub spi_t);

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -112,7 +112,6 @@ impl Drop for File {
     }
 }
 
-
 /// A directory in the file system
 ///
 /// The directory can be iterated over, producing directory entries one by one.

--- a/src/ztimer/mod.rs
+++ b/src/ztimer/mod.rs
@@ -259,7 +259,6 @@ impl embedded_hal_async::delay::DelayNs for Delay {
     }
 }
 
-
 impl<const F: u32> embedded_hal::delay::DelayNs for Clock<F> {
     // FIXME: Provide delay_us and delay_ms, at least for the clocks where those fit, to avoid the
     // loops where the provided function wakes up every 4.3s


### PR DESCRIPTION
Going with the standard config (all customizations that were used required nightly) allows us to do the fmt checks on stable, which sidesteps problems around not every nightly having fmt.

The alternative was pinning to a nightly version, and that quickly gets old. (Hah.)