### PR TITLE
Release 0.8.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,10 @@ jobs:
       # and all relevant crates once, and after that, just make some notes in Cargo.lock
       run: |
         set -x
-        for MANIF in $(find RIOT -name Cargo.toml)
+        # It is important to cd in early, for otherwise the patch.crates-io
+        # will not catch on during the update
+        cd RIOT
+        for MANIF in $(find -name Cargo.toml)
         do
             echo "::group::Updating ${MANIF}"
             cargo update -p riot-sys -p riot-wrappers --aggressive --manifest-path $MANIF
@@ -105,7 +108,10 @@ jobs:
       # and all relevant crates once, and after that, just make some notes in Cargo.lock
       run: |
         set -x
-        for MANIF in $(find RIOT -name Cargo.toml)
+        # It is important to cd in early, for otherwise the patch.crates-io
+        # will not catch on during the update
+        cd RIOT
+        for MANIF in $(find -name Cargo.toml)
         do
             echo "::group::Updating ${MANIF}"
             cargo update -p riot-sys -p riot-wrappers --aggressive --manifest-path $MANIF

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 rust-version = "1.75"


### PR DESCRIPTION
Changes:

* Optimize panic handlers

  panic_handler_crash now sidesteps additional error reporting that may have been possible depending on the interrupt state.

* Add support for embedded-nal-async 0.7
* Gcoap: Fix building on 64bit platforms
* Inspect BINDGEN_OUTPUT_FILE instead of linked riot-sys environment variables at build time
* Don't use custom rustfmt configuration

Waiting for https://github.com/RIOT-OS/RIOT/pull/20489 where those receive the extra testing of the full RIOT CI