### PR TITLE
CI: Don't continue on error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
   examples-and-tests:
     runs-on: ubuntu-latest
     container: riot/riotbuild
-    # Best would be "continue until there are errors from different examples *and* different boards"
-    continue-on-error: true
     strategy:
       matrix:
         # This is the subset of `make -f makefiles/app_dirs.inc.mk


### PR DESCRIPTION
The property was set to see more characteristics of errors in a single CI run, but has led to CI checks showing green on the required all-done check when some tests failed.

In particular, https://github.com/RIOT-OS/rust-riot-wrappers/pull/84 would have become mergeable even though the rust-gcoap examples failed (for yet unknown reasons)