### PR TITLE
ws281x: Use static inline function through inline namespace

### DIFF
--- a/src/ws281x.rs
+++ b/src/ws281x.rs
@@ -48,7 +48,9 @@ impl<C: ChannelType + Default + Copy, const N: usize> BufferedWs281x<C, N> {
 impl<C: ChannelType, const N: usize> BufferedWs281x<C, N> {
     pub fn write(&mut self) {
         unsafe {
-            riot_sys::ws281x_prepare_transmission(crate::inline_cast_mut(&mut self.dev as *mut _));
+            riot_sys::inline::ws281x_prepare_transmission(crate::inline_cast_mut(
+                &mut self.dev as *mut _,
+            ));
             riot_sys::ws281x_write_buffer(
                 &mut self.dev,
                 &self.buffer as *const _ as *const core::ffi::c_void,
@@ -56,7 +58,9 @@ impl<C: ChannelType, const N: usize> BufferedWs281x<C, N> {
                     .try_into()
                     .expect("Buffer exceeds experssible range"),
             );
-            riot_sys::ws281x_end_transmission(crate::inline_cast_mut(&mut self.dev as *mut _));
+            riot_sys::inline::ws281x_end_transmission(crate::inline_cast_mut(
+                &mut self.dev as *mut _,
+            ));
         }
     }
 }


### PR DESCRIPTION
Unblocks: https://github.com/RIOT-OS/RIOT/pull/20562

The module probably got broken when the inline functions were not automatically exported to the main namespace any more. Now that 20562 enables it on default boards, it is built the first time since 2021, and can now be built again.

There is no standalone test for this yet; it can be tested from RIOT by bending .cargo/config.toml to this branch, and running `USEMODULE+=ws281x make -C examples/rust-gcoap BOARD=microbit-v2` (which failed to build before, and now builds).