### PR TITLE
build: Select heapless-crate with features for GBA support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bare-metal = "1"
 
 cstr = "^0.2.11"
 
-heapless = "^0.7"
+heapless =  { version="0.8", features = ["portable-atomic-unsafe-assume-single-core"] }
 rand_core_06 = { package = "rand_core", version = "^0.6" }
 
 # For nimble UUID parsing and some debug implementations


### PR DESCRIPTION
Hey 🦋

This change is needed to compile RIOT/examples/rust-hello-world for the GBA.
I am aware that this is not the right way to do it but I am not yet proficient with Rust yet, so... please help! :) 

The `portable-atomic` [documentation](https://docs.rs/portable-atomic/latest/portable_atomic/) even mentions the GBA.
The version bump of `heapless` is needed as [the feature](https://docs.rs/crate/heapless/latest/features#portable-atomic-unsafe-assume-single-core) is not yet present in `0.7.x`.