### PR TITLE
Implement new module for integration Matter with RIOT OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,14 @@ embedded-hal-async = { version = "1", optional = true }
 
 critical-section = { version = "1.0", optional = true }
 
+# for with_matter feature
+rs-matter = { git = "https://github.com/maikerlab/rs-matter", branch = "feature/RIOT_OS", default-features = false, features = ["riot-os"], optional = true }
+embassy-futures = { version = "0.1.1", optional = true }
+embassy-sync = { version = "0.5.0", optional = true }
+embassy-executor-riot = { git = "https://gitlab.com/etonomy/riot-module-examples", optional = true }
+embassy-executor = { version = "0.5", features = ["nightly"], optional = true }
+log = { version =  "0.4.21", optional = true }
+
 [build-dependencies]
 shlex = "0.1.1"
 syn = { version = "1.0.107", features = [ "parsing" ] }
@@ -92,6 +100,8 @@ with_embedded_hal_async = [ "embedded-hal-async" ]
 # See msg::v2 documentation. Enabling this exposes components not under semver
 # guarantees.
 with_msg_v2 = []
+
+with_matter = ["rs-matter", "with_embedded_nal_async", "embassy-futures", "embassy-sync", "embassy-executor-riot", "embassy-executor", "log"]
 
 # Use actual `!` rather than the stable Never workaround. As far as the
 # workaround is understood, this causes no actual change in any types, just in

--- a/src/gnrc/netapi.rs
+++ b/src/gnrc/netapi.rs
@@ -1,6 +1,9 @@
 use riot_sys::gnrc_nettype_t;
-
 use crate::gnrc::pktbuf::{Pktsnip, Shared};
+use riot_sys::inline::gnrc_netapi_set;
+use riot_sys::{netopt_t_NETOPT_IPV6_GROUP, size_t};
+use crate::thread::KernelPID;
+use core::ffi::c_void;
 
 /// Dispatch a packet to all listeners of the given nettype and demux context.
 ///
@@ -20,4 +23,12 @@ pub fn dispatch_send(
         unsafe { riot_sys::inline::gnrc_pktbuf_release(crate::inline_cast_mut(pkt)) };
     }
     subscribers
+}
+
+/// Joins an IPV6 multicast group at the provided address
+pub fn join_multicast_v6(pid: KernelPID, addr: &[u8; 16]) {
+    unsafe {
+        let addr_ptr = addr.as_ptr() as *const c_void;
+        let _ = gnrc_netapi_set(pid.into(), netopt_t_NETOPT_IPV6_GROUP, 0, addr_ptr, addr.len() as size_t);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,3 +192,11 @@ pub mod led;
 pub mod auto_init;
 
 mod async_helpers;
+
+#[cfg(all(
+    riot_module_sock_udp,
+    riot_module_sock_aux_local,
+    feature = "with_embedded_nal_async",
+    feature = "with_matter"
+))]
+pub mod matter;

--- a/src/matter.rs
+++ b/src/matter.rs
@@ -1,0 +1,114 @@
+use crate::println;
+use crate::mutex::Mutex;
+use crate::socket_embedded_nal_async_udp::UnconnectedUdpSocket;
+use crate::ztimer;
+
+use embedded_nal_async::{SocketAddr, UnconnectedUdp};
+use embassy_futures::select::{Either, select};
+use embedded_hal_async::delay::DelayNs as _;
+use embassy_sync::{
+    signal::Signal,
+    blocking_mutex::raw::NoopRawMutex,
+};
+use rs_matter::error::{Error, ErrorCode};
+use rs_matter::transport::network::{UdpReceive, UdpSend};
+use log::{debug, warn, error, Level, LevelFilter, Log, Record, SetLoggerError};
+
+pub struct UdpSocketWrapper {
+    local_addr: SocketAddr,
+    socket: Mutex<UnconnectedUdpSocket>,
+    release_socket_notification: Notification,
+    socket_released_notification: Notification,
+}
+
+struct RiotLogger;
+
+pub type Notification = Signal<NoopRawMutex, ()>;
+
+static LOGGER: RiotLogger = RiotLogger;
+
+impl Log for RiotLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        metadata.level() >= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("[{}] {}", record.level(), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init_logger(level: LevelFilter) -> Result<(), SetLoggerError> {
+    log::set_logger(&LOGGER)
+        .map(|_| log::set_max_level(level))
+}
+
+impl UdpSocketWrapper {
+    pub fn new(local_addr: SocketAddr, socket: UnconnectedUdpSocket) -> Self {
+        Self {
+            local_addr,
+            socket: Mutex::new(socket),
+            release_socket_notification: Notification::new(),
+            socket_released_notification: Notification::new(),
+        }
+    }
+}
+
+impl UdpSend for &UdpSocketWrapper {
+    async fn send_to(&mut self, data: &[u8], addr: SocketAddr) -> Result<(), Error> {
+        if addr.is_ipv4() {
+            // IPv4 not supported!
+            return Ok(());
+        }
+        // Tell recv_from to release mutex
+        self.release_socket_notification.signal(());
+        ztimer::Delay.delay_ms(10).await;
+        let mut sock = self.socket.try_lock().expect("receiver should have ensured that this mutex is free");
+        sock.send(self.local_addr, addr, data)
+            .await
+            .map_err(|_| Error::new(ErrorCode::StdIoError))?;
+        // Release socket and notify recv_from -> sending is finished
+        drop(sock);
+        self.socket_released_notification.signal(());
+        Ok(())
+    }
+}
+
+impl UdpReceive for &UdpSocketWrapper {
+    async fn recv_from(&mut self, buffer: &mut [u8]) -> Result<(usize, SocketAddr), Error> {
+        loop {
+            let mut sock = self.socket.try_lock().expect("sender should have ensured that this mutex is free");
+            match select(
+                self.release_socket_notification.wait(),
+                sock.receive_into(buffer),
+            ).await {
+                Either::First(_) => {
+                    // Release Mutex for send_to
+                    drop(sock);
+                    // ... and wait until available again
+                    self.socket_released_notification.wait().await;
+                    continue;
+                }
+                Either::Second(res) => {
+                    match res {
+                        Ok((bytes_recvd, local_addr, remote_addr)) => {
+                            if remote_addr.is_ipv4() {
+                                // IPv4 not supported!
+                                return Ok((bytes_recvd, remote_addr));
+                            }
+                        }
+                        Err(_) => { error!("Error during UDP receive!"); }
+                    }
+                    // return receive result
+                    let (bytes_recvd, remote_addr) = res.map(|(bytes_recvd, _, remote_addr)|
+                        (bytes_recvd, remote_addr)
+                    ).map_err(|_| Error::new(ErrorCode::StdIoError))?;
+                    return Ok((bytes_recvd, remote_addr));
+                }
+            }
+        }
+    }
+}

--- a/src/matter.rs
+++ b/src/matter.rs
@@ -14,7 +14,7 @@ use rs_matter::error::{Error, ErrorCode};
 use rs_matter::transport::network::{UdpReceive, UdpSend};
 use log::{debug, warn, error, Level, LevelFilter, Log, Record, SetLoggerError};
 
-pub struct UdpSocketWrapper {
+pub struct MatterCompatUdpSocket {
     local_addr: SocketAddr,
     socket: Mutex<UnconnectedUdpSocket>,
     release_socket_notification: Notification,
@@ -46,7 +46,7 @@ pub fn init_logger(level: LevelFilter) -> Result<(), SetLoggerError> {
         .map(|_| log::set_max_level(level))
 }
 
-impl UdpSocketWrapper {
+impl MatterCompatUdpSocket {
     pub fn new(local_addr: SocketAddr, socket: UnconnectedUdpSocket) -> Self {
         Self {
             local_addr,
@@ -57,7 +57,7 @@ impl UdpSocketWrapper {
     }
 }
 
-impl UdpSend for &UdpSocketWrapper {
+impl UdpSend for &MatterCompatUdpSocket {
     async fn send_to(&mut self, data: &[u8], addr: SocketAddr) -> Result<(), Error> {
         if addr.is_ipv4() {
             // IPv4 not supported!
@@ -77,7 +77,7 @@ impl UdpSend for &UdpSocketWrapper {
     }
 }
 
-impl UdpReceive for &UdpSocketWrapper {
+impl UdpReceive for &MatterCompatUdpSocket {
     async fn recv_from(&mut self, buffer: &mut [u8]) -> Result<(usize, SocketAddr), Error> {
         loop {
             let mut sock = self.socket.try_lock().expect("sender should have ensured that this mutex is free");


### PR DESCRIPTION
Summary:

- Implementation of a new `matter` module, which contains "glue code" between the [rs-matter](https://github.com/maikerlab/rs-matter/tree/feature/RIOT_OS) library and RIOT OS
- Added new feature `with_matter`, which will enable the `matter` module by activation