### PR TITLE
Added static_data module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,3 +192,6 @@ pub mod led;
 pub mod auto_init;
 
 mod async_helpers;
+
+mod static_data;
+pub use static_data::StaticData;

--- a/src/static_data.rs
+++ b/src/static_data.rs
@@ -1,0 +1,78 @@
+use core::cell::UnsafeCell;
+use core::sync::atomic::AtomicBool;
+
+pub struct StaticData<T> {
+    taken: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+// Self::taken atomically guarantees Self::data can be referenced only once
+unsafe impl<T> Sync for StaticData<T> {}
+
+/// Wrapper for safely defining variables with static storage.
+///
+/// On embedded, large static data structures are often required (e.g. buffers).
+/// This is a workaround the borrow checker to safely obtain exactly one reference
+/// to mutable static data. Trying to obtain a second reference will panic.
+impl<T> StaticData<T> {
+    pub const fn new(val: T) -> Self {
+        Self {
+            data: UnsafeCell::new(val),
+            taken: AtomicBool::new(false),
+        }
+    }
+
+    /// Obtain a mutable reference to the static data. Will panic if called more
+    /// than once.
+    ///
+    /// ## Panics
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// static BUF: StaticData<[u8; 8]> = StaticData::new([0; 8]);
+    ///
+    /// let buf: &'static mut [u8; 8]  = BUF.take();
+    /// buf[0] = 99;
+    /// assert_eq!(buf[0], 99);
+    /// ```
+    pub fn take(&'static self) -> &mut T {
+        assert!(
+            !self.taken.swap(true, core::sync::atomic::Ordering::Acquire),
+            "taken more than once!"
+        );
+        unsafe {
+            // Ordering::Acquire above ensures we get to this point iff this
+            // is the first reference
+            &mut *self.data.get()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_once() {
+        static BUF: StaticData<[u8; 8]> = StaticData::new([0; 8]);
+
+        let buf = BUF.take();
+
+        buf[0] = 99;
+        assert_eq!(buf[0], 99);
+    }
+
+    #[test]
+    #[should_panic]
+    fn take_twice() {
+        static BUF: StaticData<[u8; 8]> = StaticData::new([0; 8]);
+
+        let buf1 = BUF.take();
+        let buf2 = BUF.take();
+
+        // we should not reach this point
+        buf1[0] = 99;
+        assert_eq!(buf2[0], 99);
+    }
+}


### PR DESCRIPTION
## Contribution

It might be the case that I am re-inventing the wheel, but to this moment, I could find no obvious way of defining mutable data with static storage. This is often required for large data structures that are not possible to allocate on stack (e.g. buffers).

This PR adds a `static_data` module, a safe wrapper that allows obtaining **exactly one** mutable reference to static data.

## Testing
I tested this on native in a small application, but I could not find a way to successfully run `cargo test`.