### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 rust-version = "1.75"


### PR DESCRIPTION
Changes:

* thread_measure_stack_free: Adjust to API change in RIOT
* Deprecate broken phydat unit name access in favor of `.name_owned()`
* ws281x: Update to function/inline change