### PR TITLE
Shell: Usability fixes and test

### DIFF
--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -187,7 +187,7 @@ pub trait CommandList<const BUFSIZE: usize = { riot_sys::SHELL_DEFAULT_BUFSIZE a
     /// The handler will be called every time the command is entered, and is passed the arguments
     /// including its own name in the form of [Args]. Currently, RIOT ignores the return value of
     /// the function.
-    fn and<'a, H, T>(self, name: &'a CStr, desc: &'a CStr, handler: H) -> Command<'a, Self, H, T>
+    fn and<'a, H, T>(self, name: &'a CStr, desc: &'a CStr, handler: H) -> impl CommandList<BUFSIZE>
     where
         H: FnMut(&mut stdio::Stdio, Args<'_>) -> T,
         T: crate::main::Termination,

--- a/tests/shell/Cargo.toml
+++ b/tests/shell/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "riot-wrappers-test-shell"
+version = "0.1.0"
+authors = ["Christian Amsüss <chrysn@fsfe.org>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+[profile.release]
+panic = "abort"
+
+[dependencies]
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -1,0 +1,10 @@
+# name of your application
+APPLICATION = riot-wrappers-test-shell
+BOARD ?= native
+APPLICATION_RUST_MODULE = riot_wrappers_test_shell
+BASELIBS += $(APPLICATION_RUST_MODULE).module
+FEATURES_REQUIRED += rust_target
+
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/shell/src/lib.rs
+++ b/tests/shell/src/lib.rs
@@ -1,0 +1,40 @@
+#![no_std]
+
+use core::fmt::Write;
+use riot_wrappers::println;
+use riot_wrappers::riot_main;
+use riot_wrappers::shell::CommandList;
+
+riot_main!(main);
+
+fn main() -> ! {
+    let mut nonglobal_state = 0;
+
+    // Not running anything fancy with run_once (where we could, for example, play around with
+    // different buffer sizes) because .
+
+    riot_wrappers::shell::new()
+        .and(
+            c"closure",
+            c"Run a command that holds a mutable reference",
+            |stdout, _args| {
+                writeln!(stdout, "Previous state was {}", nonglobal_state).unwrap();
+                nonglobal_state += 1;
+                writeln!(stdout, "New state is {}", nonglobal_state).unwrap();
+            },
+        )
+        .run_forever()
+}
+
+fn do_echo(_stdio: &mut riot_wrappers::stdio::Stdio, args: riot_wrappers::shell::Args<'_>) {
+    println!("Arguments:");
+    for a in args.iter() {
+        println!("- {}", a);
+    }
+}
+riot_wrappers::static_command!(
+    echo,
+    "echo",
+    "Print the arguments in separate lines",
+    do_echo
+);

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+def test(child):
+    child.expect("> ")
+    child.sendline("help")
+    # Could also be the other sequence, we're not guaranteeing that
+    commands = ["closure", "echo"]
+    helps = ["Run a command that holds a mutable reference", "Print the arguments in separate lines"]
+    command1 = child.expect(commands)
+    help1 = child.expect(helps)
+    command2 = child.expect(commands)
+    help2 = child.expect(helps)
+    if command1 != help1 or command2 != help2:
+        print("Commands and helps were mixed up")
+        sys.exit(1)
+    child.expect("> ")
+    child.sendline("echo foo bar")
+    child.expect("- echo")
+    child.expect("- foo")
+    child.expect("- bar")
+    child.expect("> ")
+    child.sendline("closure")
+    child.expect("New state is 1")
+    child.expect("> ")
+    child.sendline("closure")
+    child.expect("New state is 2")
+
+if __name__ == "__main__":
+    sys.exit(run(test))


### PR DESCRIPTION
This primarily fixes https://github.com/RIOT-OS/rust-riot-wrappers/issues/76 by returning an impl trait in a trait (which was not available back around 0.7 when that issue was introduced).

To avoid this kind of regressions in the future, a test is added.