### PR TITLE
Use ztimer_acquire and provide methods based on that kind of locking

### DIFF
--- a/tests/ztimer-async/src/lib.rs
+++ b/tests/ztimer-async/src/lib.rs
@@ -19,8 +19,21 @@ fn main() -> ! {
 async fn amain(spawner: embassy_executor::Spawner) {
     use riot_wrappers::ztimer::*;
 
+    let msec = Clock::msec();
+
+    let locked = msec.acquire();
+
     println!("Waiting 500 ticks on the msec timer before doing anything else");
-    Clock::msec().sleep_async(Ticks(500)).await;
+    let before = locked.now();
+    msec.sleep_async(Ticks(500)).await;
+    let after = locked.now();
+    println!(
+        "That took us from {:?} to {:?}, which is {} ticks.",
+        before,
+        after,
+        (after - before).0
+    );
+    drop(locked);
     println!("And now for something more complex...");
 
     spawner.spawn(ten_tenths());

--- a/tests/ztimer-async/src/lib.rs
+++ b/tests/ztimer-async/src/lib.rs
@@ -24,6 +24,8 @@ async fn amain(spawner: embassy_executor::Spawner) {
     let locked = msec.acquire();
 
     println!("Waiting 500 ticks on the msec timer before doing anything else");
+    // Locking and taking before/after is a bit crude, but the `.time()` method is not yet
+    // available for asynchronous closures.
     let before = locked.now();
     msec.sleep_async(Ticks(500)).await;
     let after = locked.now();

--- a/tests/ztimer/Cargo.toml
+++ b/tests/ztimer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "riot-wrappers-test-ztimer"
+version = "0.1.0"
+authors = ["Christian Amsüss <chrysn@fsfe.org>"]
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+[profile.release]
+panic = "abort"
+
+[dependencies]
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }

--- a/tests/ztimer/Makefile
+++ b/tests/ztimer/Makefile
@@ -1,0 +1,11 @@
+# name of your application
+APPLICATION = riot-wrappers-test-ztimer
+BOARD ?= native
+APPLICATION_RUST_MODULE = riot_wrappers_test_ztimer
+BASELIBS += $(APPLICATION_RUST_MODULE).module
+FEATURES_REQUIRED += rust_target
+
+USEMODULE += ztimer_usec
+USEMODULE += ztimer_msec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer/src/lib.rs
+++ b/tests/ztimer/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+
+use riot_wrappers::println;
+use riot_wrappers::riot_main;
+
+riot_main!(main);
+
+fn main() {
+    use riot_wrappers::ztimer::*;
+
+    let msec = Clock::msec();
+
+    println!("Waiting 500 ticks on the msec timer before doing anything else");
+    let duration = msec.time(|| {
+        msec.sleep_ticks(500);
+    });
+    let duration =
+        duration.expect("That should not have taken so long that the milliseconds overflowed");
+    println!("That took {} ticks", duration.0);
+}

--- a/tests/ztimer/tests/01-run.py
+++ b/tests/ztimer/tests/01-run.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from testrunner import run
+
+def test(child):
+    match_1 = child.expect("That took")
+
+if __name__ == "__main__":
+    sys.exit(run(test))


### PR DESCRIPTION
This adds a way to acquire a clock, a `.now()` method on acquired clock, and `.time()` method for timing functions as they are being executed.