### PR TITLE
Various warning fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "riot-wrappers"
 version = "0.8.999" # really 0.9.0-alpha.1, but we also try hard to not break realistic 0.8 users who fixed all deprecation warnings and don't hold things wrong.
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.77"
 
 description = "Rust API wrappers for the RIOT operating system"
 documentation = "https://rustdoc.etonomy.org/riot_wrappers/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "riot-wrappers"
 version = "0.8.999" # really 0.9.0-alpha.1, but we also try hard to not break realistic 0.8 users who fixed all deprecation warnings and don't hold things wrong.
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.77.0"
 
 description = "Rust API wrappers for the RIOT operating system"
 documentation = "https://rustdoc.etonomy.org/riot_wrappers/"

--- a/build.rs
+++ b/build.rs
@@ -36,6 +36,13 @@ fn main() {
         "CONFIG_AUTO_INIT_ENABLE_DEBUG",
     ];
 
+    for marker in BOOLEAN_FLAGS {
+        println!(
+            "cargo::rustc-check-cfg=cfg(marker_{})",
+            marker.to_lowercase()
+        );
+    }
+
     for (def, val) in defines {
         if val != "1" {
             // So far, only processing boolean flags

--- a/build.rs
+++ b/build.rs
@@ -62,4 +62,48 @@ fn main() {
             println!("cargo:rustc-cfg=marker_{}", def.to_lowercase());
         }
     }
+
+    println!("cargo::rustc-check-cfg=cfg(riot_develhelp)");
+
+    // FIXME: This list is currently maintained manually;
+    let known_modules = &[
+        "auto_init",
+        "auto_init_random",
+        "bluetil_ad",
+        "core_msg",
+        "gcoap",
+        "gnrc",
+        "gnrc_icmpv6",
+        "gnrc_pktbuf",
+        "gnrc_udp",
+        "ipv6",
+        "microbit",
+        "nimble_host",
+        "periph_adc",
+        "periph_dac",
+        "periph_gpio",
+        "periph_i2c",
+        "periph_spi",
+        "prng_shaxprng",
+        "pthread",
+        "random",
+        "saul",
+        "shell",
+        "sock",
+        "sock_aux_local",
+        "sock_tcp",
+        "sock_udp",
+        "udp",
+        "vfs",
+        "ws281x",
+        "ztimer",
+        "ztimer_msec",
+        "ztimer_periodic",
+        "ztimer_sec",
+        "ztimer_usec",
+    ];
+
+    for module in known_modules {
+        println!("cargo::rustc-check-cfg=cfg(riot_module_{})", module);
+    }
 }

--- a/src/coap_message/impl_0_3.rs
+++ b/src/coap_message/impl_0_3.rs
@@ -7,6 +7,7 @@ use crate::error::NumericError;
 
 /// Thin wrapper around NumericError that can render and satisfies all conversion requirements
 #[derive(Debug)]
+#[allow(dead_code)] // reason: It's indeed just for Debug
 pub struct Error(NumericError);
 
 impl From<NumericError> for Error {

--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -179,7 +179,7 @@ where
         let h = riot_sys::coap_request_ctx_get_context(context) as *mut H;
 
         let h = &mut *h;
-        let mut pb = PacketBuffer {
+        let pb = PacketBuffer {
             pkt: &mut *pkt,
             buf,
             len: len.try_into().unwrap(),

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -9,7 +9,6 @@ mod impl_1;
 use riot_sys::{gpio_clear, gpio_mode_t, gpio_read, gpio_set, gpio_t, gpio_toggle, gpio_write};
 
 use crate::error::NegativeErrorExt;
-use core::convert::Infallible;
 
 /// A Rust representation of RIOT's gpio_t, representing a single pin in no particular
 /// configuration.

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -155,6 +155,18 @@ impl OutputGPIO {
     pub fn set_state(&mut self, state: bool) {
         unsafe { gpio_write(self.to_c(), state as _) };
     }
+
+    /// Toggles the pin between high and low.
+    ///
+    /// Unlike [`set_high()`] and [`set_low()`], this is not just an alias of the [embedded-hal
+    /// trait method of the same
+    /// name](https://docs.rs/embedded-hal/latest/embedded_hal/digital/trait.StatefulOutputPin.html#method.toggle):
+    /// RIOT GPIO pins do not implement [`embedded_hal::digital::StatefulOutputPin`] because they
+    /// can not read back their configured state (but *can* toggle by implementation).
+    #[doc(alias = "gpio_toggle")]
+    pub fn toggle(&mut self) {
+        unsafe { gpio_toggle(self.to_c()) };
+    }
 }
 
 /// A [GPIO] configured and usable for input

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -50,7 +50,7 @@ impl crate::thread::InThread {
     /// Using this on an `InThread` token is preferred over the global function, as the function
     /// only returns reliable values when called from a thread context.
     pub fn irq_is_enabled(self) -> bool {
-        unsafe { riot_sys::irq_is_enabled() }
+        irq_is_enabled()
     }
 }
 

--- a/src/main_module.rs
+++ b/src/main_module.rs
@@ -168,6 +168,7 @@ impl<E: fmt::Debug> Termination for Result<crate::never::Never, E> {
                 println!("Error: {:?}", err);
                 1
             }
+            #[allow(unreachable_patterns)] // reason: RIOT CI's stable is still 1.77
             Ok(never) => never,
         }
     }

--- a/src/saul/mod.rs
+++ b/src/saul/mod.rs
@@ -479,7 +479,7 @@ impl Unit {
     pub fn name_owned<const S: usize>(self) -> Option<heapless::String<S>> {
         let mut result = heapless::String::new();
         // SAFETY: The C API will only write UTF-8 bytes.
-        let mut bytes = unsafe { result.as_mut_vec() };
+        let bytes = unsafe { result.as_mut_vec() };
         // SAFETY: C API promises to write only up to S bytes, will not write NULL byte.
         let len = unsafe {
             riot_sys::phydat_unit_write(

--- a/src/saul/registration.rs
+++ b/src/saul/registration.rs
@@ -14,7 +14,6 @@ use riot_sys::libc;
 
 use super::{Class, Phydat};
 use crate::error::NegativeErrorExt;
-use core::convert::Infallible;
 
 /// The single error read and write operations may produce; corresponds to an `-ECANCELED`.
 /// (-ENOTSUP is expressed by not having support for the operation in the first place, indicated by

--- a/src/socket_embedded_nal_async_udp.rs
+++ b/src/socket_embedded_nal_async_udp.rs
@@ -24,7 +24,7 @@ impl UdpStack {
         remote: Option<UdpEp>,
         flags: u16,
     ) -> Result<&'static mut sock_udp_t, NumericError> {
-        let mut socket = (self.static_socket_factory)().ok_or(ENOSPC)?;
+        let socket = (self.static_socket_factory)().ok_or(ENOSPC)?;
         Ok(unsafe {
             riot_sys::sock_udp_create(
                 socket.as_mut_ptr(),
@@ -316,7 +316,7 @@ macro_rules! implementation_module {
     }
     impl ReceiveIntoArgs<'_> {
         unsafe extern "C" fn callback(
-            sock: *mut sock_udp_t,
+            _sock: *mut sock_udp_t,
             flags: riot_sys::sock_async_flags_t,
             arg: *mut riot_sys::libc::c_void,
         ) {

--- a/src/socket_embedded_nal_async_udp.rs
+++ b/src/socket_embedded_nal_async_udp.rs
@@ -122,7 +122,7 @@ macro_rules! implementation_module {
             &self,
             local: $ena_crate::SocketAddr,
         ) -> Result<Self::MultiplyBound, Self::Error> {
-            let mut socket = self.create(Some(local.into()), None, 0)?;
+            let socket = self.create(Some(local.into()), None, 0)?;
 
             Ok(UnconnectedUdpSocket { socket })
         }

--- a/src/ztimer/mod.rs
+++ b/src/ztimer/mod.rs
@@ -240,7 +240,9 @@ impl<const HZ: u32> Clock<HZ> {
     #[doc(alias = "ztimer_acquire")]
     pub fn acquire(&self) -> LockedClock<HZ> {
         // ztimer_acquire is inline or non-inline depending on ZTIMER_ONDEMAND
+        #[allow(unused_imports)] // reason: which of these is used depends on ZTIMER_ONDEMAND
         use riot_sys::inline::*;
+        #[allow(unused_imports)] // reason: which of these is used depends on ZTIMER_ONDEMAND
         use riot_sys::*;
 
         // ztimer_acquire takes a mut even though ztimer itself takes care of synchronization
@@ -309,7 +311,9 @@ impl<const HZ: u32> LockedClock<HZ> {
 impl<const HZ: u32> Drop for LockedClock<HZ> {
     fn drop(&mut self) {
         // ztimer_release is inline or non-inline depending on ZTIMER_ONDEMAND
+        #[allow(unused_imports)] // reason: which of these is used depends on ZTIMER_ONDEMAND
         use riot_sys::inline::*;
+        #[allow(unused_imports)] // reason: which of these is used depends on ZTIMER_ONDEMAND
         use riot_sys::*;
 
         // ztimer_release takes a mut even though ztimer itself takes care of synchronization

--- a/src/ztimer/mod.rs
+++ b/src/ztimer/mod.rs
@@ -136,7 +136,7 @@ impl<const HZ: u32> ValueInThread<Clock<HZ>> {
         ticks: Ticks<HZ>,
         in_thread: M,
     ) -> R {
-        (*self).set_during(callback, ticks, in_thread)
+        self.into_inner().set_during(callback, ticks, in_thread)
     }
 }
 


### PR DESCRIPTION
We've been racking up warnings, in part because changes to Rust caused so many warnings to show up that the relevant ones got drowned.

Fixing them piece by piece.