### PR TITLE
CI: Block warnings (with warnings fixes)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 # Ideally this should be replaced with a call out to Murdock; until that is
 # practical, building representative examples.
 
+# Ad RUSTFLAGS=-Dwarnings: While this is generally discouraged (for it means
+# that new Rust versions break CI), in this case we don't get new Rust versions
+# all the time but only on riotdocker updates, and that's a good time to
+# reflect on whether the new warnings make sense or not.
+
 name: test
 
 on:
@@ -58,7 +63,7 @@ jobs:
 
     - name: Build the example
       run: |
-        make all BOARD=${{ matrix.board }} -C RIOT/${{ matrix.example }}
+        RUSTFLAGS=-Dwarnings make all BOARD=${{ matrix.board }} -C RIOT/${{ matrix.example }}
 
   enumerate-wrappers-tests:
     runs-on: ubuntu-latest
@@ -128,7 +133,7 @@ jobs:
         cd ${{ matrix.testdir }}
         if BOARDS=${{ matrix.board }} make info-boards-supported | grep -q .
         then
-          BOARD=${{ matrix.board }} make all
+          BOARD=${{ matrix.board }} RUSTFLAGS=-Dwarnings make all
 
           if [ "native" = "${{ matrix.board }}" ] && make test/available BOARD=native
           then

--- a/src/impl_critical_section.rs
+++ b/src/impl_critical_section.rs
@@ -3,7 +3,7 @@
 
 use critical_section::RawRestoreState;
 
-struct CriticalSection(usize);
+struct CriticalSection;
 critical_section::set_impl!(CriticalSection);
 
 unsafe impl critical_section::Impl for CriticalSection {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,4 +184,10 @@ pub mod led;
 #[cfg(riot_module_auto_init)]
 pub mod auto_init;
 
+// Gated like socket_embedded_nal_async_udp as it is only used there -- expand as needed.
+#[cfg(all(
+    riot_module_sock_udp,
+    riot_module_sock_aux_local,
+    feature = "with_embedded_nal_async"
+))]
 mod async_helpers;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -64,6 +64,8 @@ impl Into<riot_sys::sock_udp_ep_t> for UdpEp {
     }
 }
 
+// Gated to its users to avoid dead code warnings
+#[cfg(any(feature = "with_embedded_nal", feature = "with_embedded_nal_async"))]
 macro_rules! implementation_no_std_net {
     ($nsn_crate:ident) => {
         use super::*;

--- a/src/ztimer/mod.rs
+++ b/src/ztimer/mod.rs
@@ -169,7 +169,7 @@ impl<const HZ: u32> Clock<HZ> {
         ticks: Ticks<HZ>,
         in_thread: M,
     ) -> R {
-        use core::{cell::UnsafeCell, mem::ManuallyDrop};
+        use core::cell::UnsafeCell;
 
         // This is zero-initialized, which is the more efficient mode for ztimer_t.
         let mut timer = riot_sys::ztimer_t::default();

--- a/tests/led/src/lib.rs
+++ b/tests/led/src/lib.rs
@@ -19,9 +19,9 @@ fn main() {
     ];
     loop {
         for i in 0..=255 {
-            for j in 0..8 {
+            for (j, led) in leds.iter_mut().enumerate() {
                 if (i ^ (i - 1)) & (1 << j) != 0 {
-                    leds[j].toggle().unwrap();
+                    led.toggle().unwrap();
                 }
             }
         }

--- a/tests/random/src/lib.rs
+++ b/tests/random/src/lib.rs
@@ -7,7 +7,7 @@ use riot_wrappers::riot_main;
 riot_main!(main);
 
 fn check_csrng(mut rng: impl rand_core::CryptoRng + rand_core::RngCore) {
-    use rngcheck::{helpers::*, nist::*};
+    use rngcheck::nist::*;
 
     // This is also in https://github.com/ryankurte/rngcheck/pull/3
     struct BitIter<'a, R: rand_core::RngCore> {

--- a/tests/ztimer-async/src/lib.rs
+++ b/tests/ztimer-async/src/lib.rs
@@ -11,7 +11,9 @@ fn main() -> ! {
         static_cell::StaticCell::new();
     let executor: &'static mut _ = EXECUTOR.init(embassy_executor_riot::Executor::new());
     executor.run(|spawner| {
-        spawner.spawn(amain(spawner));
+        spawner
+            .spawn(amain(spawner))
+            .expect("Task did not get spawned before");
     })
 }
 
@@ -38,8 +40,12 @@ async fn amain(spawner: embassy_executor::Spawner) {
     drop(locked);
     println!("And now for something more complex...");
 
-    spawner.spawn(ten_tenths());
-    spawner.spawn(five_fifths());
+    spawner
+        .spawn(ten_tenths())
+        .expect("Task did not get spawned before");
+    spawner
+        .spawn(five_fifths())
+        .expect("Task did not get spawned before");
 }
 
 #[embassy_executor::task]


### PR DESCRIPTION
This adds the equivalent of `-Werror` to the CI builds.

> While this is generally discouraged (for it means that new Rust versions break CI), in this case we don't get new Rust versions all the time but only on riotdocker updates, and that's a good time to reflect on whether the new warnings make sense or not.

Let's see how well that works; I rather add `#[allow(...)]` generously in the codebase than have so many warnings that important ones get overshadowed.

Along with the actual change, all the fixes that would previously have caused warnings (now errors) come in.