### PR TITLE
vfs: Buffer names for nul termination

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -107,6 +107,7 @@ macro_rules! E {
 
 // See module level comment
 E!(EAGAIN);
+E!(EINVAL);
 E!(ENOMEM);
 E!(ENOSPC);
 E!(EOVERFLOW);

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -90,9 +90,10 @@ impl File {
     /// Open a file in read-only mode.
     pub fn open(path: &str) -> Result<Self, NumericError> {
         let path = NameNullTerminated::new(path)?;
-        let fileno =
-            unsafe { riot_sys::vfs_open(path.as_cstr()?.as_ptr(), riot_sys::O_RDONLY as _, 0) }
-                .negative_to_error()?;
+        let fileno = unsafe {
+            riot_sys::vfs_open(path.as_cstr()?.as_ptr() as _, riot_sys::O_RDONLY as _, 0)
+        }
+        .negative_to_error()?;
         Ok(File {
             fileno,
             _not_send_sync: PhantomData,
@@ -150,7 +151,7 @@ impl Dir {
     pub fn open(dir: &str) -> Result<Self, NumericError> {
         let dir = NameNullTerminated::new(dir)?;
         let mut dirp = MaybeUninit::uninit();
-        (unsafe { riot_sys::vfs_opendir(dirp.as_mut_ptr(), dir.as_cstr()?.as_ptr()) })
+        (unsafe { riot_sys::vfs_opendir(dirp.as_mut_ptr(), dir.as_cstr()?.as_ptr() as _) })
             .negative_to_error()?;
         let dirp = unsafe { dirp.assume_init() };
         Ok(Dir(dirp, core::marker::PhantomPinned))


### PR DESCRIPTION
This fixes a severe bug where file names were passed to the C API that expects nul-termination.

This incurs some copying overhead, which fortunately is not too bad due to the name length limit.

Closes: https://github.com/RIOT-OS/rust-riot-wrappers/issues/93

Thanks @maikerlab for reporting this. AIU it went unnoticed because in my tests, the &str often came from what was originally nul-terminated, eg. from the command line, or from CoAP where the option byte is sometimes replaced with a \0 as a part gcoap's internal processing.