### PR TITLE
Change version to 0.9, merging breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.8.999" # really 0.9.0-alpha.1, but we also try hard to not break realistic 0.8 users who fixed all deprecation warnings and don't hold things wrong.
+version = "0.9.0"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 rust-version = "1.77.0"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,64 @@
+# Changes in 0.9.0
+
+## Breaking changes
+
+*These items will require code changes for all who use them.*
+
+* VFS: Opening directories now takes a pinned slot to store the open directory in.
+
+* ZTimer: Sleep functions were renamed for consistency
+
+  * `sleep()` became `sleep_extended()`
+
+  * `sleep_ticks()` became `sleep()` and takes `Ticks(u32)` instead of a plain `u32`
+
+* Support for all outdated traits was removed:
+
+  * `embedded-hal` 0.2 (except for ADC and SPI)
+  
+  * `coap-handler` 0.1 and `coap-message` 0.2
+
+  * `embedded-nal-async` 0.6
+
+## Subtle breakage
+
+*These items will only require code changes for users who had unresolved deprecation warnings,
+or who explicitly named clock or error types.*
+
+* All deprecated items were removed.
+
+* gcoap: `PacketBuffer` now has a lifetime.
+
+* saul: `Unit` is non-exhaustive.
+
+* shell: `.and()` returns an `impl CommandList` instead of a `Command`.
+  This drastically enhances usability because chaining is now possible without extra effort going into type annotations.
+
+* ztimer: Clocks are now generated as `ValueInThread<Clock<HZ>>`
+  and require to stay in a thread to allow using the `sleep{,_*}` methods.
+
+* Traits that previously used `!` as associated error type
+  now use `Infallible`.
+
+* Dependencies: heapless is now used in version 0.8.
+  This is a public dependency because `saul::Unit::name_owned` returns a buffer.
+
+## Enhancements
+
+* gpio: `.toggle()` was added.
+
+* shell: `.run_forever()` and `.run_once()` are now available with provided buffers;
+  the previous `…_providing_buf()` variants are now deprecated aliases.
+
+* ztimer: Timers can be `.acquire()`'d and then provide a `.now()` method,
+  as provide a `.time()` method to measure the execution time of a closure.
+
+## Bug fixes
+
+* VFS: Fixed out-of-bounds read for file names that were not nul-terminated.
+
+## Internal changes
+
+* Tests were added for shell and ztimer.
+
+* Rust shows no more warnings for this crate.

--- a/tests/ztimer/src/lib.rs
+++ b/tests/ztimer/src/lib.rs
@@ -12,7 +12,7 @@ fn main() {
 
     println!("Waiting 500 ticks on the msec timer before doing anything else");
     let duration = msec.time(|| {
-        msec.sleep_ticks(500);
+        msec.sleep(Ticks(500));
     });
     let duration =
         duration.expect("That should not have taken so long that the milliseconds overflowed");


### PR DESCRIPTION
This turns the version up to 0.9 for real (after a period on 0.8.999 since https://github.com/RIOT-OS/rust-riot-wrappers/pull/90).

Changing the version and pulling breaking changes from https://github.com/RIOT-OS/rust-riot-wrappers/pull/104 and https://github.com/RIOT-OS/rust-riot-wrappers/pull/108 means that this PR's CI will *not* pass. However, the individual PRs pulled in passed in their own PRs with "DO NOT MERGE" commits on top that bend the affected repositories (RIOT, riot-module-examples) to the respective 0.9 branch.

This PR will be merged ignoring the failing CI. Once it is published, RIOT and riot-module-examples can get their own updates that go to 0.9. The alternative to this rather brutal approach is to bend CI now to test against the branches, and then do an extra PR bending it back -- I think that the risk of things going wrong on that track are larger than those of just merging this.