### PR TITLE
doc: Make all doctests buildable once more

### DIFF
--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -88,7 +88,12 @@ impl GPIO {
     /// Create a GPIO from its port and pin numbers
     ///
     /// ```
+    /// # #![no_std]
+    /// # #![no_main]
+    /// # fn f() {
+    /// use riot_wrappers::gpio::GPIO;
     /// let pin_c8 = GPIO::from_port_and_pin(3, 8);
+    /// # }
     /// ```
     ///
     /// See [from_c] for safety constraints.

--- a/src/main_module.rs
+++ b/src/main_module.rs
@@ -91,7 +91,8 @@ impl<F: Fn(StartToken) -> ((), EndToken)> UsableAsMain<[u8; 3]> for F {
 ///
 /// ```
 /// # #![no_std]
-/// # use riot_wrappers::riot_main;
+/// # #![no_main]
+/// use riot_wrappers::riot_main;
 /// riot_main!(main);
 ///
 /// fn main() {

--- a/src/msg/v2.rs
+++ b/src/msg/v2.rs
@@ -171,16 +171,14 @@ pub trait MessageSemantics: Sized {
     ///
     /// ```
     /// # #![no_std]
-    /// # #![feature(start)]
-    /// # #[start]
-    /// # fn main(_argc: isize, _argv: *const *const u8) -> isize {
-    /// # use riot_wrappers::msg::v2::*;
-    /// # let message_semantics = unsafe { NoConfiguredMessages::new() };
+    /// # #![no_main]
+    /// # fn f() {
+    /// use riot_wrappers::msg::v2::*;
+    /// # let message_semantics = NoConfiguredMessages; // FIXME: constructing this should not be possible publicly
     /// type NumberReceived = ReceivePort<u32, 1>;
     /// type BoolReceived = ReceivePort<bool, 2>;
     /// let (message_semantics, receive_num, send_num): (_, NumberReceived, _) = message_semantics.split_off();
     /// let (message_semantics, receive_bool, send_bool): (_, BoolReceived, _) = message_semantics.split_off();
-    /// # 0
     /// # }
     /// ```
     ///


### PR DESCRIPTION
With work going on on https://github.com/RIOT-OS/rust-documentation-builder for more reliable documentation and tests building, a few bugs (and overly complicated constructs) were found in this crate's doctests, and fixed here.

This is also the first PR since the 0.9 manual merging and subsequent update of RIOT, so let's see how CI fares.