### PR TITLE
gcoap: Allow upgrading MinimalWritableMessage to MutableWritableMessage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ coap-numbers = "^0.2.0"
 
 embedded-graphics = "0.6"
 
-coap-message-0-3 = { package = "coap-message", version = "^0.3.0" }
+coap-message-0-3 = { package = "coap-message", version = "^0.3.3" }
 coap-handler-0-2 = { package = "coap-handler", version = "^0.2.0" }
 embedded-nal = { version = "0.6.0", optional = true }
 embedded-nal-tcpextensions = { version = "0.1", optional = true }

--- a/src/coap_message/impl_0_3.rs
+++ b/src/coap_message/impl_0_3.rs
@@ -86,6 +86,12 @@ impl<'a> MinimalWritableMessage for super::ResponseMessage<'a> {
         self.payload_mut_with_len(data.len())?.copy_from_slice(data);
         Ok(())
     }
+
+    #[inline]
+    #[allow(refining_impl_trait_reachable)]
+    fn promote_to_mutable_writable_message(&mut self) -> Option<&mut Self> {
+        Some(self)
+    }
 }
 
 impl<'a> MutableWritableMessage for super::ResponseMessage<'a> {


### PR DESCRIPTION
This enhances how the gcoap stack can be used with error handlers.

See [the new implemented method's docs](https://docs.rs/coap-message/latest/coap_message/trait.MinimalWritableMessage.html#method.promote_to_mutable_writable_message) for details.