### PR TITLE
doc: Fix errors

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -20,7 +20,7 @@ impl ADCLine {
 
     /// Initialize an ADC line identified by the line number it is assigned on the board
     ///
-    /// Safety: See [.init()]
+    /// Safety: See [Self::init()]
     pub unsafe fn from_number(line: u32) -> Result<Self, i32> {
         let line = riot_sys::macro_ADC_LINE(line);
         Self::init(line)

--- a/src/async_helpers.rs
+++ b/src/async_helpers.rs
@@ -14,7 +14,7 @@ use core::future::Future;
 /// While this can legally be implemented without unsafe, practical use will require unsafe, and
 /// that requires sticking to the rules:
 ///
-/// * Whenever [.poll()] is called, do whatever the future needs to do after having been awoken. If
+/// * Whenever [Self::poll()] is called, do whatever the future needs to do after having been awoken. If
 ///   this returns [core::task::Poll::Pending] (and the future wants to be polled ever again), it
 ///   must then pass on the `arg` to some RIOT callback setter together with a static function of a
 ///   suitable signature. Conventionally, that function is called `Self::callback()`.

--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -96,7 +96,7 @@ impl GPIO {
     /// # }
     /// ```
     ///
-    /// See [.from_c()] for safety constraints.
+    /// See [Self::from_c()] for safety constraints.
     pub fn from_port_and_pin(port: u32, pin: u32) -> Option<Self> {
         Self::from_c(unsafe { riot_sys::macro_GPIO_PIN(port, pin) })
     }


### PR DESCRIPTION
The fixes in [125] made the warnigns go away, but [`.foo()`] does not fix the warnings, it just looks so wrong that rustdoc doesn't even warn any more.

[125]: https://github.com/RIOT-OS/rust-riot-wrappers/pull/125