### PR TITLE
Error enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.4", features = ["u
 embedded-hal = "1"
 switch-hal = "0.4.0"
 nb = "0.1.1"
-riot-sys = "0.7.13"
+riot-sys = "0.7.14"
 num-traits = { version = "0.2", default-features = false }
 mutex-trait = "0.2"
 

--- a/build.rs
+++ b/build.rs
@@ -104,6 +104,8 @@ fn main() {
         "sock_aux_local",
         "sock_tcp",
         "sock_udp",
+        "tiny_strerror",
+        "tiny_strerror_minimal",
         "udp",
         "vfs",
         "ws281x",

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
 //! Common error handling components for the RIOT operating system
 //!
+//! Most fallible operations in the wrappers produce a [NumericError], which is a slightly more
+//! precise wrapper around a negative integer. The [NegativeErrorExt::negative_to_error()] trait
+//! method can be used to produce such errors when creating wrappers around C functions.
+//!
 //! ## Constants
 //!
 //! Several commonly used errors are provided as constants rather than requiring the use of

--- a/src/error.rs
+++ b/src/error.rs
@@ -103,13 +103,12 @@ where
         if self >= Self::zero() {
             Ok(self)
         } else {
-            Err(NumericError {
-                number: self
-                    .try_into()
-                    .ok()
-                    .and_then(NonZero::new)
-                    .unwrap_or(NonZero::new(-(riot_sys::EOVERFLOW as isize)).unwrap()),
-            })
+            Err(self
+                .try_into()
+                .ok()
+                .and_then(NonZero::new)
+                .map(|number| NumericError { number })
+                .unwrap_or(EOVERFLOW))
         }
     }
 }


### PR DESCRIPTION
A goal with the NegativeError type is to tell the compiler that all positive values are niches. While that's impossible or at least hard and compile time heavy, advertising the niche at 0 to the compiler is easy enough.

Along with this comes a documentation extension and minor internal refactorings.