### PR TITLE
[WIP] gcoap: adapt to API change in PR 20900

### DIFF
--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -380,7 +380,7 @@ impl<'b> PacketBuffer<'b> {
     }
 
     pub fn set_code_raw(&mut self, code: u8) {
-        unsafe { (*(*self.pkt).hdr).code = code };
+        unsafe { riot_sys::inline::coap_pkt_set_code(self.pkt as *mut coap_pkt_t as *mut riot_sys::inline::coap_pkt_t, code) };
     }
 
     /// Return the total number of bytes in the message, given that `payload_used` bytes were


### PR DESCRIPTION
In PR 20900 promotes access to header fields through helper functions on the C side, in the hope that this will allow similar but not quite UDP transports in addition to UDP (TCP and WebSocket) directly in nanocoap. This adapts and uses a helper to access the header instead.