### PR TITLE
gcoap: adapt to API change in [PR20900]

### DIFF
--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -380,7 +380,16 @@ impl<'b> PacketBuffer<'b> {
     }
 
     pub fn set_code_raw(&mut self, code: u8) {
-        unsafe { (*(*self.pkt).hdr).code = code };
+        #[cfg(accessible_riot_sys_inline_coap_pkt_set_code)]
+        {
+            unsafe {
+                riot_sys::inline::coap_pkt_set_code(crate::inline_cast_ref_mut(self.pkt), code)
+            };
+        }
+        #[cfg(not(accessible_riot_sys_inline_coap_pkt_set_code))]
+        {
+            unsafe { (*(*self.pkt).hdr).code = code };
+        }
     }
 
     /// Return the total number of bytes in the message, given that `payload_used` bytes were

--- a/src/gnrc/netreg.rs
+++ b/src/gnrc/netreg.rs
@@ -30,7 +30,7 @@ type PktsnipPort = crate::msg::v2::SendPort<
 ///
 /// It might be convenient for this to return at some point (in case of short-lived network
 /// services). Deregistration could be done and everything returned alright -- but the grant would
-/// still be lost. This could be mitigated by accepting a 'static PktsnipPort or a clonable version
+/// still be lost. This could be mitigated by accepting a 'static PktsnipPort or a cloneable version
 /// thereof -- not that anything could still be recombined after that, but at least it could be
 /// used once more (with the risk that messages from the old registration arrive in the new one,
 /// which is wrong correctness-wise but safe because it'll still be a pointer to a pktsnip).

--- a/src/msg/v2.rs
+++ b/src/msg/v2.rs
@@ -74,7 +74,7 @@ pub struct ReceivePort<TYPE: Send, const TYPENO: u16> {
 /// share a shared reference), it would be possible to create a version of the SendPort
 /// that counts its clones at runtime and can only be returned when all of them are recombined, or
 /// just to create a version that can be cloned at will but never recombined any more. (One way to
-/// do the latter would be to add a const boolean type parameter "CLONED"; a `.clonable(self) ->
+/// do the latter would be to add a const boolean type parameter "CLONED"; a `.cloneable(self) ->
 /// Self` would switch that from false to true, and then copy and clone would be implemented for
 /// the result, whereas recombination would only be implemented for the CLONED = false version).
 pub struct SendPort<TYPE: Send, const TYPENO: u16> {


### PR DESCRIPTION
While [PR20900] provides a compatibility .hdr accessor through a union, that trick is not available through bindgen or c2rust, which all introduce a dummy-named field for the anonymous union. Instead, we follow the path set out by [PR79] and introspect the source file.

[PR20900]: https://github.com/RIOT-OS/RIOT/pull/20900
[PR79]: https://github.com/RIOT-OS/rust-riot-wrappers/pull/79

Replaces and thus closes: #129

@maribu, please verify that this aligns with [PR20900].