### PR TITLE
doc: Typo fixes

### DIFF
--- a/src/gnrc/netreg.rs
+++ b/src/gnrc/netreg.rs
@@ -30,7 +30,7 @@ type PktsnipPort = crate::msg::v2::SendPort<
 ///
 /// It might be convenient for this to return at some point (in case of short-lived network
 /// services). Deregistration could be done and everything returned alright -- but the grant would
-/// still be lost. This could be mitigated by accepting a 'static PktsnipPort or a clonable version
+/// still be lost. This could be mitigated by accepting a 'static PktsnipPort or a cloneable version
 /// thereof -- not that anything could still be recombined after that, but at least it could be
 /// used once more (with the risk that messages from the old registration arrive in the new one,
 /// which is wrong correctness-wise but safe because it'll still be a pointer to a pktsnip).

--- a/src/msg/v2.rs
+++ b/src/msg/v2.rs
@@ -74,7 +74,7 @@ pub struct ReceivePort<TYPE: Send, const TYPENO: u16> {
 /// share a shared reference), it would be possible to create a version of the SendPort
 /// that counts its clones at runtime and can only be returned when all of them are recombined, or
 /// just to create a version that can be cloned at will but never recombined any more. (One way to
-/// do the latter would be to add a const boolean type parameter "CLONED"; a `.clonable(self) ->
+/// do the latter would be to add a const boolean type parameter "CLONED"; a `.cloneable(self) ->
 /// Self` would switch that from false to true, and then copy and clone would be implemented for
 /// the result, whereas recombination would only be implemented for the CLONED = false version).
 pub struct SendPort<TYPE: Send, const TYPENO: u16> {


### PR DESCRIPTION
Blocks #130 from getting past CI

@Kijewski, do you know of any trick that'll make typo checks only fatal in new code?