### PR TITLE
gpio: Refactor use of RIOT's gpio_read()

### DIFF
--- a/src/gpio/mod.rs
+++ b/src/gpio/mod.rs
@@ -188,11 +188,11 @@ impl InputGPIO {
     }
 
     pub fn is_high(&self) -> bool {
-        unsafe { gpio_read(self.to_c()) != 0 }
+        unsafe { i32::from(gpio_read(self.to_c())) != 0 }
     }
 
     pub fn is_low(&self) -> bool {
-        unsafe { gpio_read(self.to_c()) == 0 }
+        !self.is_high()
     }
 }
 
@@ -223,10 +223,10 @@ impl InOutGPIO {
     }
 
     pub fn is_high(&self) -> bool {
-        unsafe { gpio_read(self.to_c()) != 0 }
+        unsafe { i32::from(gpio_read(self.to_c())) != 0 }
     }
 
     pub fn is_low(&self) -> bool {
-        unsafe { gpio_read(self.to_c()) == 0 }
+        !self.is_high()
     }
 }


### PR DESCRIPTION
C callers of gpio_read() do not care whether gpio_read() returns an pre C99 style `bool` (which is an `int` with every non-zero number being a valid representation of `true`) or C99 style `bool`, as long as the stay within spec (treating representation of `true` as `true` with no regard to the encoding).

This refactors the rust use to match the C behavior. This would allow updating `gpio_read()` to return C99 style `bool` as type.