### PR TITLE
doc: Update URI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 rust-version = "1.79.0"
 
 description = "Rust API wrappers for the RIOT operating system"
-documentation = "https://rustdoc.etonomy.org/riot_wrappers/"
+documentation = "https://doc.riot-os.org/rustdoc/latest/riot_wrappers/"
 repository = "https://github.com/RIOT-OS/rust-riot-wrappers"
 keywords = ["riot", "riot-os", "iot", "bindings", "embedded-hal-impl"]
 categories = ["api-bindings", "no-std"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ System](https://riot-os.org/)'s C API exposed by riot-sys and
 makes an attempt to provide idiomatic Rust wrappers (eg. implementing
 embedded-hal for peripherals, implementing fmt::Write for stdio) around those.
 
-The [crate documentation](https://rustdoc.etonomy.org/riot_wrappers/) outlines which
+The [crate documentation](https://doc.riot-os.org/rustdoc/latest/riot_wrappers/) outlines which
 modules are available, and which other crates' traits they implement.
 
 For a newcomer's starting point, see [RIOT's documentation on using it with Rust].


### PR DESCRIPTION
Documentation is now synced into there, and the old URI is merely a redirect.