### PR TITLE
deny: Allow newer Unicode license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,10 +2,10 @@
 version = 2
 # We'll generally add license here as long as they're OSI approved, but let's keep an eye on them…
 allow = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT"]
-# … and for those, I'd rather doublecheck:
+# … and for those, I'd rather doublecheck (all are either FSF or OSI approved):
 exceptions = [
   { allow = ["LGPL-2.1"], crate = "riot-sys" },
-  { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
+  { allow = ["Unicode-DFS-2016", "Unicode-3.0"], crate = "unicode-ident" },
 ]
 private = { ignore = true }
 confidence-threshold = 1.0


### PR DESCRIPTION
The latest version of `unicode-ident` switched license, which tripped up `cargo-deny` checks. See https://github.com/RIOT-OS/rust-riot-wrappers/pull/124#issuecomment-2508169864 for the long-term story, but to fix this now, the license is well within what can be allowed.