### PR TITLE
msg: Typo fix

### DIFF
--- a/src/msg/v2.rs
+++ b/src/msg/v2.rs
@@ -159,7 +159,7 @@ impl<TYPE: Send, const TYPENO: u16> core::fmt::Debug for SendPort<TYPE, TYPENO> 
 /// Trait for types that indicate the current thread's readiness to receive some set of messages
 ///
 /// In a sense, a MessageSemantics is factory for mutually nonconflicting [ReceivePort]s, and a
-/// tracker of what was alerady issued.
+/// tracker of what was already issued.
 // TBD: seal? can still unseal later.
 pub trait MessageSemantics: Sized {
     // TBD: Would be great to be const


### PR DESCRIPTION
A typo that the latest dictionary update caught.

This is cherry-picked from https://github.com/RIOT-OS/rust-riot-wrappers/pull/141 where it tripped up the CI checks, which should rebase onto this branch to avoid having that spurious commit in the PR.