### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riot-wrappers"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Christian Amsüss <chrysn@fsfe.org>"]
 edition = "2021"
 rust-version = "1.79.0"


### PR DESCRIPTION
RIOT is in hard freeze and this version is planned for 2025.01 -- and should thus also be on crates.io for easy use in out-of-tree applications.

There's a rustfmt underformatting that my local tools report; let's see what CI says, and look into whether anything needs to be added (but ideally after the release).

Procedurally, once this is ready to be merged, I'll upload the tag and then merge it. (I'm not familiar enough with the automation around that to trust GitHub actions to upload to crates.io).

---

Changes:

* UART support added.
* SPI reimplemented for embedded-hal 1.0.
* Adjust to RIOT API changes in gcoap, GPIO, shell XFA.
* Error enhancements (niche used, Display and Error added, pretty if tiny_strerror is available).
* GNRC enhancements (simplifications, debug, added methods).
* Added contributing guide.
* Documentation fixes.
