### PR TITLE
errors: Negate in `NumericError::from_constant`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -68,7 +68,9 @@ impl NumericError {
             Some(n) => n,
             _ => panic!("Error names are expected to be positive for conversion into negative error numbers.")
         };
-        NumericError { number }
+        NumericError {
+            number: number.saturating_neg(),
+        }
     }
 
     /// Numeric value of the error


### PR DESCRIPTION
As stated in the function's comment, `number` should be negated. Otherwise, things like `again_is_wouldblock` don't work correctly.
I think this missing was just an oversight from https://github.com/RIOT-OS/rust-riot-wrappers/commit/021cfa9cd8720e8e9049fb317592df9e3c46c8f0.