### PR TITLE
treewide: update links to RIOT examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         # This is the subset of `make -f makefiles/app_dirs.inc.mk
         # info-applications` that is probably relevant; more is covered when
         # riot-wrappers are updated in RIOT.
-        example: [examples/rust-hello-world, examples/rust-gcoap, examples/rust-async, tests/rust_minimal, tests/rust_libs]
+        example: [examples/lang_support/official/rust-hello-world, examples/lang_support/official/rust-gcoap, examples/lang_support/official/rust-async, tests/rust_minimal, tests/rust_libs]
         board: [native, sltb001a, samr21-xpro, stk3700, stm32f429i-disc1, usb-kw41z]
     steps:
     # common steps start here

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The [crate documentation](https://doc.riot-os.org/rustdoc/latest/riot_wrappers/)
 modules are available, and which other crates' traits they implement.
 
 For a newcomer's starting point, see [RIOT's documentation on using it with Rust].
-For basic code examples see [RIOT's examples](https://github.com/RIOT-OS/RIOT/tree/master/examples)
+For basic code examples see [RIOT's examples](https://github.com/RIOT-OS/RIOT/tree/master/examples/lang_support/official)
 (those with "rust" in their name), and the
 [additional examples](https://gitlab.com/etonomy/riot-examples/)
 which showcase more of the wrapped APIs.


### PR DESCRIPTION
As follow-up of https://github.com/RIOT-OS/RIOT/pull/21135 and https://github.com/RIOT-OS/RIOT/pull/21221

(Note that the workflow is expected to fail until the latter PR is merged)