### PR TITLE
Fix warnings

### DIFF
--- a/src/gnrc/mod.rs
+++ b/src/gnrc/mod.rs
@@ -108,6 +108,6 @@ impl Netif {
     }
 
     pub fn l2addr(&self) -> &[u8] {
-        unsafe { &(*self.0).l2addr[..(*self.0).l2addr_len as usize] }
+        unsafe { &(&(*self.0).l2addr)[..(*self.0).l2addr_len as usize] }
     }
 }

--- a/src/gnrc_pktbuf.rs
+++ b/src/gnrc_pktbuf.rs
@@ -105,7 +105,7 @@ impl<M: Mode> Pktsnip<M> {
         (unsafe { riot_sys::inline::gnrc_pkt_count(crate::inline_cast(self.ptr)) }) as _
     }
 
-    pub fn iter_snips(&self) -> SnipIter {
+    pub fn iter_snips(&self) -> SnipIter<'_> {
         SnipIter {
             pointer: self.ptr,
             datalifetime: PhantomData,
@@ -114,7 +114,7 @@ impl<M: Mode> Pktsnip<M> {
 
     // This is like a wrapper around gnrc_pktsnip_search_type, but given how simple that function
     // is, wrapping it to correct lifetimes would be more verbose than just re-implementing it.
-    pub fn search_type(&self, type_: gnrc_nettype_t) -> Option<PktsnipPart> {
+    pub fn search_type(&self, type_: gnrc_nettype_t) -> Option<PktsnipPart<'_>> {
         self.iter_snips().filter(|x| x.type_ == type_).next()
     }
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -49,7 +49,7 @@ impl<T> Mutex<T> {
     /// better [`.lock()`](crate::thread::ValueInThread<&Mutex<T>>::lock) method, which suffers
     /// neither the panic condition nor the runtime overhead.
     #[doc(alias = "mutex_lock")]
-    pub fn lock(&self) -> MutexGuard<T> {
+    pub fn lock(&self) -> MutexGuard<'_, T> {
         crate::thread::InThread::new()
             .expect("Mutex::lock may only be called outside of interrupt contexts")
             .promote(self)
@@ -58,7 +58,7 @@ impl<T> Mutex<T> {
 
     /// Get an accessor to the mutex if the mutex is available
     #[doc(alias = "mutex_trylock")]
-    pub fn try_lock(&self) -> Option<MutexGuard<T>> {
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
         match unsafe { riot_sys::mutex_trylock(self.mutex.get()) } {
             1 => Some(MutexGuard { mutex: &self }),
             _ => None,

--- a/src/stdio.rs
+++ b/src/stdio.rs
@@ -1,6 +1,6 @@
 //! Wrappers for the [stdio](https://doc.riot-os.org/group__sys__stdio.html)
 
-use core::intrinsics::transmute;
+use core::mem::transmute;
 use riot_sys::{stdio_read, stdio_write};
 
 use crate::error::NegativeErrorExt;

--- a/src/thread/riot_c/creation.rs
+++ b/src/thread/riot_c/creation.rs
@@ -1,8 +1,8 @@
 use super::{KernelPID, Status};
 
 use core::ffi::CStr;
-use core::intrinsics::transmute;
 use core::marker::PhantomData;
+use core::mem::transmute;
 use riot_sys as raw;
 use riot_sys::libc;
 

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -349,7 +349,7 @@ impl<'a> Mount<'a> {
     /// internal to it; a second call to this function may produce an empty iterator (just like
     /// attempting to read entries from an already exhausted [Dir] does); this may change if VFS's
     /// directories gain rewind support.
-    pub fn root_dir(&mut self) -> &'a mut Dir {
+    pub fn root_dir(&mut self) -> &'a mut Dir<'_> {
         // unsafe: Legitimized by the Dir being transparent, and by Dir not doing anything that'd
         // invalidate the dir's openness as long as it's not owned.
         unsafe { &mut *(self.0 as *mut _ as *mut _) }

--- a/tests/spi/src/lib.rs
+++ b/tests/spi/src/lib.rs
@@ -35,7 +35,8 @@ fn main() {
     // difference in the outcome, it's more to cover the full API surface.
     let Ok(mut spi_with_soft_cs) = embedded_hal_bus::spi::ExclusiveDevice::new(
         spi,
-        cs.configure_as_output(riot_wrappers::gpio::OutputMode::Out).unwrap(),
+        cs.configure_as_output(riot_wrappers::gpio::OutputMode::Out)
+            .unwrap(),
         riot_wrappers::ztimer::Clock::usec(),
     );
     test_on_device(&mut spi_with_soft_cs);


### PR DESCRIPTION
A number of warnings that were previously absent came up with recent compiler versions.

Also, there's a subtle change in formatting (not sure if cargo-fmt behavior change of just a long-unfixed formatting bug).