### PR TITLE
chore(ws281x): do some API impedance matching

### DIFF
--- a/src/ws281x.rs
+++ b/src/ws281x.rs
@@ -48,9 +48,7 @@ impl<C: ChannelType + Default + Copy, const N: usize> BufferedWs281x<C, N> {
 impl<C: ChannelType, const N: usize> BufferedWs281x<C, N> {
     pub fn write(&mut self) {
         unsafe {
-            riot_sys::inline::ws281x_prepare_transmission(crate::inline_cast_mut(
-                &mut self.dev as *mut _,
-            ));
+            riot_sys::ws281x_prepare_transmission(crate::inline_cast_mut(&mut self.dev as *mut _));
             riot_sys::ws281x_write_buffer(
                 &mut self.dev,
                 &self.buffer as *const _ as *const core::ffi::c_void,
@@ -58,9 +56,7 @@ impl<C: ChannelType, const N: usize> BufferedWs281x<C, N> {
                     .try_into()
                     .expect("Buffer exceeds experssible range"),
             );
-            riot_sys::inline::ws281x_end_transmission(crate::inline_cast_mut(
-                &mut self.dev as *mut _,
-            ));
+            riot_sys::ws281x_end_transmission(crate::inline_cast_mut(&mut self.dev as *mut _));
         }
     }
 }


### PR DESCRIPTION
See https://github.com/RIOT-OS/rust-riot-sys/pull/63 for context