### PR TITLE
Create an `rust_eh_personality` symbol rather than attempting to populate the lang item

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,6 @@
 //! [this crate's README file]: https://github.com/RIOT-OS/rust-riot-wrappers
 
 #![no_std]
-// for eh_personality; only needed on native
-#![cfg_attr(
-    all(
-        feature = "set_panic_handler",
-        target_arch = "x86",
-        not(panic = "abort")
-    ),
-    feature(lang_items)
-)]
 // Primarily for documentation, see feature docs
 #![cfg_attr(feature = "actual_never_type", feature(never_type))]
 #![cfg_attr(feature = "nightly_docs", feature(fundamental))]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -58,12 +58,18 @@ fn panic(info: &::core::panic::PanicInfo) -> ! {
     }
 }
 
-// We could make this conditional also on panic="abort" and thus enable stable compilation when
-// that flag is enabled -- but then again https://github.com/rust-lang/rust/issues/77443 is not
-// stable yet so it's kind of moot (and I don't want to introduce yet another crate feature that'll
-// largely be untested).
-#[cfg(all(target_arch = "x86", not(panic = "abort")))]
-#[lang = "eh_personality"]
-fn rust_eh_personality() {
+// There is no need to set the lang item (recent Rust versions plainly err with "unwinding panics
+// are not supported without std" anyway when attempting to build without panic="abort"), but the
+// pre-built core library does panic in some situations. While CARGO_OPTIONS+=-Zbuild-std=core is a
+// viable solution, it needs nightly and is thus not suitable for docker builds (where the number
+// of installed toolchains is kept at a minimum). Instead, we merely define the symbol, which is
+// enough to fix the linker errors that would otherwise be raised in nontrivial applications.
+//
+// We need to do this on precisely those RUST_TARGET values selected through RIOT that are built
+// with unwinding panic (which is those that have std; at the time of writing,
+// i686-unknown-linux-gnu and x86_64-unknown-linux-gnu), but there is no harm in defining the
+// symbol on other platforms for simplicity.
+#[no_mangle]
+unsafe extern "C" fn rust_eh_personality() {
     loop {}
 }


### PR DESCRIPTION
The lang item has long been unused and unusable in RIOT Rust setups; the new version can solve the linker issues ("undefined reference to `rust_eh_personality'") that pop up in some applications on native.

---


Together with https://github.com/riOT-OS/rust-riot-sys/pull/66, this should allow removing the blacklist entries in the examples.