### PR TITLE
Cargo: Allow riot-sys 0.8 series

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.4", features = ["u
 embedded-hal = "1"
 switch-hal = "0.4.0"
 nb = "0.1.1"
-riot-sys = "0.7.14"
+# The promise of the 0.8.0 series is to not break riot-wrappers
+riot-sys = ">= 0.7.14, < 0.9.0"
 num-traits = { version = "0.2", default-features = false }
 mutex-trait = "0.2"
 


### PR DESCRIPTION
This helps test its pre-release branch.

See-also: https://github.com/RIOT-OS/rust-riot-sys/pull/67

---

I'll take the liberty to self-approve this, as it can only have fall-out when things are merged into riot-sys.