### PR TITLE
Fix building on native32/64 and run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         # info-applications` that is probably relevant; more is covered when
         # riot-wrappers are updated in RIOT.
         example: [examples/lang_support/official/rust-hello-world, examples/lang_support/official/rust-gcoap, examples/lang_support/official/rust-async, tests/rust_minimal, tests/rust_libs]
-        # FIXME: Restore native in RIOT master.
+        # native32/64 excluded until RIOT is updated to the riot-sys 0.8 branch and can thus unblock native tests from its tests
         board: [sltb001a, samr21-xpro, stk3700, stm32f429i-disc1, usb-kw41z]
     steps:
     # common steps start here
@@ -89,7 +89,7 @@ jobs:
     container: riot/riotbuild
     strategy:
       matrix:
-        board: [native, sltb001a, samr21-xpro, stk3700, stm32f429i-disc1, usb-kw41z]
+        board: [native32, native64, sltb001a, samr21-xpro, stk3700, stm32f429i-disc1, usb-kw41z]
         testdir: ${{ fromJSON(needs.enumerate-wrappers-tests.outputs.list) }}
     steps:
     # common steps start here (kept in sync even though we wouldn't need to patch RIOT's .cargo/config.toml)
@@ -118,18 +118,18 @@ jobs:
         then
           BOARD=${{ matrix.board }} RUSTFLAGS=-Dwarnings make all
 
-          if [ "native" = "${{ matrix.board }}" ] && make test/available BOARD=native
+          if echo "${{ matrix.board }}" | grep -q ^native && make test/available BOARD=${{ matrix.board }}
           then
             echo
             echo "Testing ${D}"
             echo
 
-            if make BOARD=native info-modules |grep -q netdev_tap; then
+            if make BOARD=${{ matrix.board }} info-modules |grep -q netdev_tap; then
               # Seems we can't have tap interfaces on GitHub actions, aborting.
               echo "Board requires tap interface, skipping."
               exit 0
             fi
-            make all test BOARD=native
+            make all test BOARD=${{ matrix.board }}
           fi
         else
           echo "Board is not supported for this test, skipping."

--- a/src/i2c/impl_1.rs
+++ b/src/i2c/impl_1.rs
@@ -6,8 +6,8 @@ use crate::error::{NegativeErrorExt, NumericError};
 
 use super::*;
 
-const I2C_NOSTOP: u8 = riot_sys::i2c_flags_t_I2C_NOSTOP;
-const I2C_NOSTART: u8 = riot_sys::i2c_flags_t_I2C_NOSTART;
+const I2C_NOSTOP: u8 = riot_sys::i2c_flags_t_I2C_NOSTOP as _;
+const I2C_NOSTART: u8 = riot_sys::i2c_flags_t_I2C_NOSTART as _;
 
 #[derive(Debug)]
 pub struct Error(NumericError);

--- a/src/socket_embedded_nal_tcp.rs
+++ b/src/socket_embedded_nal_tcp.rs
@@ -134,7 +134,7 @@ impl<'a, const QUEUELEN: usize> TcpClientStack for Pin<&'a mut ListenStack<QUEUE
             riot_sys::sock_tcp_write(
                 &mut self.as_mut().get_unchecked_mut().connections[index],
                 buf.as_ptr() as *const _,
-                buf.len().try_into().unwrap_or(u32::MAX),
+                buf.len().try_into().unwrap_or(usize::MAX as _),
             )
         }
         .negative_to_error()
@@ -154,7 +154,7 @@ impl<'a, const QUEUELEN: usize> TcpClientStack for Pin<&'a mut ListenStack<QUEUE
             riot_sys::sock_tcp_read(
                 &mut self.as_mut().get_unchecked_mut().connections[index],
                 buf.as_ptr() as *mut _,
-                buf.len().try_into().unwrap_or(u32::MAX),
+                buf.len().try_into().unwrap_or(usize::MAX as _),
                 0,
             )
         }

--- a/tests/auto-init-debug/tests/01-run.py
+++ b/tests/auto-init-debug/tests/01-run.py
@@ -13,7 +13,7 @@ def test(child):
     child.expect("Main running")
 
 if __name__ == "__main__":
-    if os.environ['BOARD'] != 'native':
+    if not os.environ['BOARD'].startswith('native'):
         print("Automated test only works on native (other boards' early output is lost)", file=sys.stderr)
         sys.exit(1)
     sys.exit(run(test))

--- a/tests/auto-init/tests/01-run.py
+++ b/tests/auto-init/tests/01-run.py
@@ -10,7 +10,7 @@ def test(child):
     child.expect("Main running")
 
 if __name__ == "__main__":
-    if os.environ['BOARD'] != 'native':
+    if not os.environ['BOARD'].startswith('native'):
         print("Automated test only works on native (other boards' early output is lost)", file=sys.stderr)
         sys.exit(1)
     sys.exit(run(test))

--- a/tests/gnrc-embedded-nal-udp/Cargo.toml
+++ b/tests/gnrc-embedded-nal-udp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "riot-wrappers-test-gnrc-embedded-nal-udp"
+version = "0.0.0"
+authors = ["Christian Amsüss <chrysn@fsfe.org>"]
+edition = "2024"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format", "with_embedded_nal" ] }
+riot-sys = "*"
+embedded-nal = "0.6.0"

--- a/tests/gnrc-embedded-nal-udp/Makefile
+++ b/tests/gnrc-embedded-nal-udp/Makefile
@@ -1,0 +1,8 @@
+# name of your application
+APPLICATION = riot-wrappers-test-gnrc-embedded-nal-udp
+APPLICATION_RUST_MODULE = riot_wrappers_test_gnrc_embedded_nal_udp
+
+USEMODULE += sock_udp
+USEMODULE += gnrc_ipv6
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc-embedded-nal-udp/src/lib.rs
+++ b/tests/gnrc-embedded-nal-udp/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+
+use riot_wrappers::{println, riot_main};
+
+use embedded_nal::{UdpClientStack, UdpFullStack};
+
+riot_main!(main);
+
+fn main() {
+    let mut stack: riot_wrappers::socket_embedded_nal::Stack<2> =
+        riot_wrappers::socket_embedded_nal::Stack::new();
+
+    stack.run(|mut stack| {
+        let mut server = stack.socket().unwrap();
+        stack.bind(&mut server, 1234).unwrap();
+
+        let mut client = stack.socket().unwrap();
+        stack.connect(&mut client, "[::1]:1234".parse().unwrap()).unwrap();
+
+        stack.send(&mut client, b"hello").unwrap();
+        let mut buf = [0; 16];
+        match stack.receive(&mut server, &mut buf) {
+            Ok((5, _)) if &buf[..5] == b"hello" => {
+                println!("Tests completed.");
+            }
+            Ok((5, _)) => {
+                println!("Tests failed: Weird, the length is right, but the content of the buffer is wrong");
+            }
+            x => {
+                println!("Tests failed: Received {x:?}.");
+            }
+        }
+
+        // No clean-up yet, so we just terminate like this:
+        loop {
+            riot_wrappers::thread::sleep();
+        }
+    });
+}

--- a/tests/gnrc-embedded-nal-udp/tests/01-run.py
+++ b/tests/gnrc-embedded-nal-udp/tests/01-run.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+def test(child):
+    child.expect_exact("Tests completed.")
+
+if __name__ == "__main__":
+    sys.exit(run(test))

--- a/tests/led/tests/01-run.py
+++ b/tests/led/tests/01-run.py
@@ -11,6 +11,6 @@ def test(child):
 
 if __name__ == "__main__":
     if os.environ['BOARD'] != 'native':
-        print("Automated test only works on native (other boards don't report hteir LED activity)", file=sys.stderr)
+        print("Automated test only works on native (other boards don't report their LED activity)", file=sys.stderr)
         sys.exit(1)
     sys.exit(run(test))

--- a/tests/led/tests/01-run.py
+++ b/tests/led/tests/01-run.py
@@ -10,7 +10,7 @@ def test(child):
     child.expect("LED_GREEN_TOGGLE")
 
 if __name__ == "__main__":
-    if os.environ['BOARD'] != 'native':
+    if not os.environ['BOARD'].startswith('native'):
         print("Automated test only works on native (other boards don't report their LED activity)", file=sys.stderr)
         sys.exit(1)
     sys.exit(run(test))


### PR DESCRIPTION
We can't use usize directly because riot-sys runs on having a distinct size_t, but we can take a usize and cast it.

---

This helps fix the coap_through_embeddednal example in https://codeberg.org/RIOT/rust-examples/pulls/7