### PR TITLE
Fix build failures due to deprecations in riot-sys

### DIFF
--- a/src/async_helpers.rs
+++ b/src/async_helpers.rs
@@ -31,7 +31,7 @@ use core::future::Future;
 ///   implementor's responsibility to not just move its data around.
 pub(crate) trait RiotStyleFuture {
     type Output;
-    fn poll(&mut self, arg: *mut riot_sys::libc::c_void) -> core::task::Poll<Self::Output>;
+    fn poll(&mut self, arg: *mut crate::libc::c_void) -> core::task::Poll<Self::Output>;
 }
 
 /// Wrapper that makes a [Future] out of a [RiotStyleFuture] (see there for usage)
@@ -55,7 +55,7 @@ impl<A: RiotStyleFuture> RiotStylePollStruct<A> {
     }
 
     /// Reconstruct a Self and run its waker (if one is present)
-    pub(crate) unsafe fn callback(arg: *mut riot_sys::libc::c_void) {
+    pub(crate) unsafe fn callback(arg: *mut crate::libc::c_void) {
         // Actually Pin<>, but we just promise not to move it.
         let f: &mut Self = &mut *(arg as *mut _);
         // If it fires multiple times, we ignore it (the waker has been taken) -- unless the future

--- a/src/gcoap.rs
+++ b/src/gcoap.rs
@@ -1,8 +1,8 @@
 use crate::error::NegativeErrorExt;
+use crate::libc;
 use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use riot_sys::libc;
 use riot_sys::{coap_optpos_t, coap_pkt_t, gcoap_listener_t};
 
 use riot_sys::coap_resource_t;

--- a/src/gnrc/netreg/callback.rs
+++ b/src/gnrc/netreg/callback.rs
@@ -59,7 +59,7 @@ pub fn register_static<C: Callback>(
     unsafe extern "C" fn c_callback<C: Callback>(
         cmd: u16,
         pkt: *mut riot_sys::gnrc_pktsnip_t,
-        ctx: *mut riot_sys::libc::c_void,
+        ctx: *mut crate::libc::c_void,
     ) {
         // unsafe: Constructed through the opposite cast, and API promises to deliver that value
         let callback = unsafe { &mut *(ctx as *mut C) };
@@ -77,7 +77,7 @@ pub fn register_static<C: Callback>(
 
     slot.1.write(riot_sys::gnrc_netreg_entry_cbd_t {
         cb: Some(c_callback::<C>),
-        ctx: slot.2.as_mut_ptr() as *mut riot_sys::libc::c_void,
+        ctx: slot.2.as_mut_ptr() as *mut crate::libc::c_void,
     });
 
     unsafe {

--- a/src/gnrc/nib.rs
+++ b/src/gnrc/nib.rs
@@ -21,7 +21,7 @@ pub enum NudState {
 }
 
 impl NudState {
-    fn from_c(input: riot_sys::libc::c_uint) -> Option<Self> {
+    fn from_c(input: crate::libc::c_uint) -> Option<Self> {
         Some(match input {
             riot_sys::GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNMANAGED => NudState::Unmanaged,
             riot_sys::GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE => NudState::Unreachable,
@@ -66,7 +66,7 @@ pub enum ArState {
 }
 
 impl ArState {
-    fn from_c(input: riot_sys::libc::c_uint) -> Option<Self> {
+    fn from_c(input: crate::libc::c_uint) -> Option<Self> {
         Some(match input {
             riot_sys::GNRC_IPV6_NIB_NC_INFO_AR_STATE_GC => ArState::Gc,
             riot_sys::GNRC_IPV6_NIB_NC_INFO_AR_STATE_TENTATIVE => ArState::Tentative,
@@ -98,7 +98,7 @@ impl NcEntry {
         // // Interfaces are positive numbers; MAX is clearly out of range and allows us to have an easier
         // // input type
         // let interface = interface.map(|i| {
-        //     riot_sys::libc::c_uint::try_from(usize::from(i)).unwrap_or(riot_sys::libc::c_uint::MAX)
+        //     crate::libc::c_uint::try_from(usize::from(i)).unwrap_or(crate::libc::c_uint::MAX)
         // });
 
         any_nc_query(0)
@@ -155,8 +155,8 @@ impl NcEntry {
 }
 
 struct NcIterator {
-    interface: riot_sys::libc::c_uint,
-    state: *mut riot_sys::libc::c_void,
+    interface: crate::libc::c_uint,
+    state: *mut crate::libc::c_void,
 }
 
 impl Iterator for NcIterator {
@@ -175,7 +175,7 @@ impl Iterator for NcIterator {
     }
 }
 
-fn any_nc_query(interface: riot_sys::libc::c_uint) -> impl Iterator<Item = NcEntry> {
+fn any_nc_query(interface: crate::libc::c_uint) -> impl Iterator<Item = NcEntry> {
     NcIterator {
         interface,
         state: core::ptr::null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@
 /// only where necessary to utilize riot-wrappers APIs.
 pub use riot_sys;
 
+// When removing, check for occurrences of `$crate::riot_sys::libc` in the modules!
+mod libc {
+    #[allow(deprecated, reason = "needed while we support riot-sys 0.7")]
+    pub use riot_sys::libc::*;
+}
+
 /// Re-exporting the cstr macro module because our macros in [shell] use it.
 pub use cstr;
 

--- a/src/msg/mod.rs
+++ b/src/msg/mod.rs
@@ -6,10 +6,10 @@
 //! pure-Rust thread doesn't accidentally reuse a number or does something else to misuse
 //! ContainerMsg::recognize; a better interface is WIP in the [v2] module.
 
+use crate::libc;
 use crate::thread::KernelPID;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use riot_sys::libc;
 use riot_sys::{self, kernel_pid_t, msg_receive, msg_reply, msg_send, msg_send_receive, msg_t};
 
 #[cfg(feature = "with_msg_v2")]

--- a/src/saul/registration.rs
+++ b/src/saul/registration.rs
@@ -9,8 +9,8 @@
 //! dispatch by being generic over the [Drivable] and exposing untyped function pointers. (In a
 //! sense, SAUL ships its own version of Rust's `dyn`, and Driver manages that).
 
+use crate::libc;
 use core::ffi::CStr;
-use riot_sys::libc;
 
 use super::{Class, Phydat};
 use crate::error::NegativeErrorExt;

--- a/src/shell/args.rs
+++ b/src/shell/args.rs
@@ -1,4 +1,4 @@
-use riot_sys::libc;
+use crate::libc;
 
 use crate::helpers::PointerToCStr;
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -23,9 +23,9 @@
 //! That complexity is not pulled in when only using [`static_command!`](crate::static_command!)
 //! and running on an otherwise empty command list.
 
+use crate::libc;
 use crate::{mutex, stdio};
 use core::ffi::CStr;
-use riot_sys::libc;
 use riot_sys::{shell_command_t, shell_run_forever, shell_run_once};
 
 mod args;
@@ -214,7 +214,7 @@ pub trait CommandList<const BUFSIZE: usize = { riot_sys::SHELL_DEFAULT_BUFSIZE a
 // downcast_mut() in the handlers to get back the right Root, verifying in the process that indeed
 // we agere on what it is in there. That currently doesn't work because the Root is not necessarily
 // 'static (but typically only lives its 'a).
-struct SleevedCommandList(*mut riot_sys::libc::c_void);
+struct SleevedCommandList(*mut crate::libc::c_void);
 
 // unsafe: The only way we access the pointer in there is through callbacks we only let RIOT from
 // the shell function, and this all happens in the same thread.

--- a/src/socket_embedded_nal_async_udp.rs
+++ b/src/socket_embedded_nal_async_udp.rs
@@ -216,7 +216,7 @@ macro_rules! implementation_module {
             ),
             NumericError,
         >;
-        fn poll(&mut self, arg: *mut riot_sys::libc::c_void) -> core::task::Poll<Self::Output> {
+        fn poll(&mut self, arg: *mut crate::libc::c_void) -> core::task::Poll<Self::Output> {
             let sock: &mut sock_udp_t = self.sock;
 
             // Using recv_buf so that we can get the full length, and thus deliver the first
@@ -318,7 +318,7 @@ macro_rules! implementation_module {
         unsafe extern "C" fn callback(
             _sock: *mut sock_udp_t,
             flags: riot_sys::sock_async_flags_t,
-            arg: *mut riot_sys::libc::c_void,
+            arg: *mut crate::libc::c_void,
         ) {
             if flags & riot_sys::inline::SOCK_ASYNC_MSG_RECV == 0 {
                 // We can get stray _MSG_SENT in here (although I'm not sure those even get

--- a/src/thread/riot_c.rs
+++ b/src/thread/riot_c.rs
@@ -177,8 +177,8 @@ impl KernelPID {
             struct ThreadOrItsStart(*const riot_sys::thread_t);
 
             // Before https://github.com/RIOT-OS/RIOT/pull/18942 (up and including 2024.04)
-            impl Into<*const riot_sys::libc::c_char> for ThreadOrItsStart {
-                fn into(self) -> *const riot_sys::libc::c_char {
+            impl Into<*const crate::libc::c_char> for ThreadOrItsStart {
+                fn into(self) -> *const crate::libc::c_char {
                     unsafe { (*self.0).stack_start }
                 }
             }

--- a/src/thread/riot_c/creation.rs
+++ b/src/thread/riot_c/creation.rs
@@ -1,10 +1,10 @@
 use super::{KernelPID, Status};
 
+use crate::libc;
 use core::ffi::CStr;
 use core::marker::PhantomData;
 use core::mem::transmute;
 use riot_sys as raw;
-use riot_sys::libc;
 
 /// Internal helper that does all the casting but relies on the caller to establish appropriate
 /// lifetimes.

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -5,7 +5,7 @@
 use core::ptr;
 
 use crate::error::{NegativeErrorExt, NumericError};
-use riot_sys::libc::{c_uint, c_void};
+use crate::libc::{c_uint, c_void};
 use riot_sys::*;
 
 /// Error representing the status returned by various `UART`-functions.

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -18,7 +18,7 @@ use core::pin::Pin;
 
 use pin_project::{pin_project, pinned_drop};
 
-use riot_sys::libc;
+use crate::libc;
 
 use crate::error::{NegativeErrorExt, NumericError};
 use crate::helpers::{PointerToCStr, SliceToCStr};

--- a/src/ztimer/mod.rs
+++ b/src/ztimer/mod.rs
@@ -193,7 +193,7 @@ impl<const HZ: u32> Clock<HZ> {
         // and nobody drops.
         let callback: *mut _ = &mut callback;
 
-        extern "C" fn caller<I: FnOnce() + Send>(arg: *mut riot_sys::libc::c_void) {
+        extern "C" fn caller<I: FnOnce() + Send>(arg: *mut crate::libc::c_void) {
             // unsafe: Was cast from the same type when assigned to arg.
             //
             // Reference construction: We're in a critical section, and the main thread only holds
@@ -598,7 +598,7 @@ impl<const HZ: u32> core::future::Future for AsyncSleep<HZ> {
             let NascentAsyncSleep { clock, ticks } = nascent;
 
             let mut timer: riot_sys::ztimer_t = Default::default();
-            extern "C" fn wake_arg(arg: *mut riot_sys::libc::c_void) {
+            extern "C" fn wake_arg(arg: *mut crate::libc::c_void) {
                 // Moving it out of its pinned position, leaving the bit pattern in place (but it
                 // won't ever be used again, as the timer only fires once).
                 let waker: core::task::Waker = unsafe { (arg as *mut core::task::Waker).read() };
@@ -624,7 +624,7 @@ impl<const HZ: u32> core::future::Future for AsyncSleep<HZ> {
             // We're casting a ManuallyDrop into the c_void here and cast it back into a Waker, but
             // that's OK because ManuallyDrop is repr(transparent)
             let waker_address = &running.waker as *const ManuallyDrop<core::task::Waker>
-                as *const riot_sys::libc::c_void;
+                as *const crate::libc::c_void;
             running.as_mut().project().timer.arg = waker_address as *mut _;
             let timer = &running.timer as *const _ as *mut _;
 

--- a/src/ztimer/periodic.rs
+++ b/src/ztimer/periodic.rs
@@ -14,12 +14,12 @@ pub enum Behavior {
     Abort = (riot_sys::ZTIMER_PERIODIC_KEEP_GOING as isize) ^ 1,
 }
 
-impl Into<riot_sys::libc::c_int> for Behavior {
-    fn into(self) -> riot_sys::libc::c_int {
+impl Into<crate::libc::c_int> for Behavior {
+    fn into(self) -> crate::libc::c_int {
         match self {
             Behavior::KeepGoing => riot_sys::ZTIMER_PERIODIC_KEEP_GOING as _,
             // "any other value"
-            Behavior::Abort => (riot_sys::ZTIMER_PERIODIC_KEEP_GOING as riot_sys::libc::c_int) ^ 1,
+            Behavior::Abort => (riot_sys::ZTIMER_PERIODIC_KEEP_GOING as crate::libc::c_int) ^ 1,
         }
     }
 }
@@ -104,7 +104,7 @@ impl<H: Handler, const HZ: u32> Timer<H, HZ> {
         }
     }
 
-    extern "C" fn callback(arg: *mut riot_sys::libc::c_void) -> bool {
+    extern "C" fn callback(arg: *mut crate::libc::c_void) -> bool {
         let handler = unsafe { &mut *(arg as *mut H) };
         handler.trigger().into()
     }


### PR DESCRIPTION
The current 0.8 version of riot-sys promises to be compatible, but introduces deprecations which CI doesn't like.

That use gets allowed while we support 0.7 and 0.8.

Commits will continue until CI is happy.