### PR TITLE
tests: Remove cruft from Makefiles

### DIFF
--- a/tests/adc/Cargo.toml
+++ b/tests/adc/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }
 riot-sys = "*"

--- a/tests/adc/Makefile
+++ b/tests/adc/Makefile
@@ -1,8 +1,6 @@
 # name of your application
 APPLICATION = riot-wrappers-test-leds
 APPLICATION_RUST_MODULE = riot_wrappers_test_leds
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 FEATURES_REQUIRED += periph_adc
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/auto-init/Cargo.toml
+++ b/tests/auto-init/Cargo.toml
@@ -8,8 +8,5 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }

--- a/tests/auto-init/Makefile
+++ b/tests/auto-init/Makefile
@@ -2,7 +2,5 @@
 APPLICATION = riot-wrappers-test-auto-init
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_auto_init
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/dac/Cargo.toml
+++ b/tests/dac/Cargo.toml
@@ -8,8 +8,5 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }

--- a/tests/dac/Makefile
+++ b/tests/dac/Makefile
@@ -1,8 +1,6 @@
 # name of your application
 APPLICATION = riot-wrappers-test-dac
 APPLICATION_RUST_MODULE = riot_wrappers_test_dac
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 FEATURES_REQUIRED += periph_dac
 
 # Of these boards it is known that DAC0 may be driven arbitrarily because it's

--- a/tests/gnrc-pktbuf/Cargo.toml
+++ b/tests/gnrc-pktbuf/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 riot-sys = "*"

--- a/tests/gnrc-pktbuf/Makefile
+++ b/tests/gnrc-pktbuf/Makefile
@@ -1,8 +1,6 @@
 # name of your application
 APPLICATION = riot-wrappers-test-gnrc-pktbuf
 APPLICATION_RUST_MODULE = riot_wrappers_test_gnrc_pktbuf
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 USEMODULE += gnrc_pktbuf
 

--- a/tests/gpio/Cargo.toml
+++ b/tests/gpio/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 embedded-hal = "1"

--- a/tests/gpio/Makefile
+++ b/tests/gpio/Makefile
@@ -1,8 +1,6 @@
 # name of your application
 APPLICATION = riot-wrappers-test-gpio
 APPLICATION_RUST_MODULE = riot_wrappers_test_gpio
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 FEATURES_REQUIRED += periph_gpio
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/i2c/Cargo.toml
+++ b/tests/i2c/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 embedded-hal = "1"

--- a/tests/i2c/Makefile
+++ b/tests/i2c/Makefile
@@ -1,8 +1,6 @@
 # name of your application
 APPLICATION = riot-wrappers-test-i2c
 APPLICATION_RUST_MODULE = riot_wrappers_test_i2c
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 FEATURES_REQUIRED += periph_i2c
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/led/Cargo.toml
+++ b/tests/led/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }
 switch-hal = "0.4"

--- a/tests/led/Makefile
+++ b/tests/led/Makefile
@@ -2,7 +2,5 @@
 APPLICATION = riot-wrappers-test-leds
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_leds
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/mutex/Cargo.toml
+++ b/tests/mutex/Cargo.toml
@@ -8,8 +8,5 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler" ] }

--- a/tests/mutex/Makefile
+++ b/tests/mutex/Makefile
@@ -1,7 +1,5 @@
 APPLICATION = riot-wrappers-test-mutex
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_mutex
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/network-properties/Cargo.toml
+++ b/tests/network-properties/Cargo.toml
@@ -8,8 +8,5 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }

--- a/tests/network-properties/Makefile
+++ b/tests/network-properties/Makefile
@@ -2,8 +2,6 @@
 APPLICATION = riot-wrappers-test-networkproperties
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_networkproperties
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 # This may not be a GNRC netdev in all cases; when it is not, the test will
 # break, and that will be the time to split it. So far, also IPv6 support can

--- a/tests/random/Cargo.toml
+++ b/tests/random/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 rand_core = "0.6"

--- a/tests/random/Makefile
+++ b/tests/random/Makefile
@@ -2,8 +2,6 @@
 APPLICATION = riot-wrappers-test-random
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_random
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 USEMODULE += random
 # So that the RNG can be Default-constructed

--- a/tests/shell/Cargo.toml
+++ b/tests/shell/Cargo.toml
@@ -8,8 +8,5 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -2,8 +2,6 @@
 APPLICATION = riot-wrappers-test-shell
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_shell
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 USEMODULE += shell
 

--- a/tests/spi/Cargo.toml
+++ b/tests/spi/Cargo.toml
@@ -7,9 +7,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 # critical-section: We don't *use* this, but the embedded-hal-bus crate also contains variants that rely on critical sections, so we have to enable it.
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format", "provide_critical_section_1_0" ] }

--- a/tests/spi/Makefile
+++ b/tests/spi/Makefile
@@ -1,7 +1,5 @@
 APPLICATION = riot-wrappers-test-spi
 APPLICATION_RUST_MODULE = riot_wrappers_test_spi
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_spi
 USEMODULE += ztimer_usec

--- a/tests/uart/Cargo.toml
+++ b/tests/uart/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }
 riot-sys = "*"

--- a/tests/uart/Makefile
+++ b/tests/uart/Makefile
@@ -1,7 +1,5 @@
 APPLICATION = riot-wrappers-test-uart
 APPLICATION_RUST_MODULE = riot_wrappers_test_uart
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 FEATURES_REQUIRED += periph_uart
 # We don't use them, but still enable them to increase build test coverage
 FEATURES_OPTIONAL += periph_uart_modecfg

--- a/tests/ztimer-async/Cargo.toml
+++ b/tests/ztimer-async/Cargo.toml
@@ -8,9 +8,6 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format", "embedded-hal-async", "provide_critical_section_1_0" ] }
 embassy-executor-riot = { git = "https://gitlab.com/etonomy/riot-module-examples" }

--- a/tests/ztimer-async/Makefile
+++ b/tests/ztimer-async/Makefile
@@ -2,8 +2,6 @@
 APPLICATION = riot-wrappers-test-ztimer_async
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_ztimer_async
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec

--- a/tests/ztimer/Cargo.toml
+++ b/tests/ztimer/Cargo.toml
@@ -8,8 +8,5 @@ publish = false
 [lib]
 crate-type = ["staticlib"]
 
-[profile.release]
-panic = "abort"
-
 [dependencies]
 riot-wrappers = { path = "../..", features = [ "set_panic_handler", "panic_handler_format" ] }

--- a/tests/ztimer/Makefile
+++ b/tests/ztimer/Makefile
@@ -2,8 +2,6 @@
 APPLICATION = riot-wrappers-test-ztimer
 BOARD ?= native
 APPLICATION_RUST_MODULE = riot_wrappers_test_ztimer
-BASELIBS += $(APPLICATION_RUST_MODULE).module
-FEATURES_REQUIRED += rust_target
 
 USEMODULE += ztimer_usec
 USEMODULE += ztimer_msec


### PR DESCRIPTION
Working on tests in #157 I found many legacy lines of Makefile, which RIOT has long since done automatically.